### PR TITLE
Added an option to not show v2 PIN reminders.

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/conversationlist/ConversationListFragment.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversationlist/ConversationListFragment.java
@@ -226,9 +226,7 @@ public class ConversationListFragment extends MainFragment implements LoaderMana
     initializeTypingObserver();
     initializeSearchListener();
 
-    if (!TextSecurePreferences.isPinV2ReminderDisabled(requireContext())) {
-      RegistrationLockDialog.showReminderIfNecessary(this);
-    }
+    RegistrationLockDialog.showReminderIfNecessary(this);
 
     TooltipCompat.setTooltipText(searchAction, getText(R.string.SearchToolbar_search_for_conversations_contacts_and_messages));
   }

--- a/app/src/main/java/org/thoughtcrime/securesms/conversationlist/ConversationListFragment.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversationlist/ConversationListFragment.java
@@ -226,7 +226,9 @@ public class ConversationListFragment extends MainFragment implements LoaderMana
     initializeTypingObserver();
     initializeSearchListener();
 
-    RegistrationLockDialog.showReminderIfNecessary(this);
+    if (!TextSecurePreferences.isPinV2ReminderDisabled(requireContext())) {
+      RegistrationLockDialog.showReminderIfNecessary(this);
+    }
 
     TooltipCompat.setTooltipText(searchAction, getText(R.string.SearchToolbar_search_for_conversations_contacts_and_messages));
   }

--- a/app/src/main/java/org/thoughtcrime/securesms/lock/RegistrationLockDialog.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/lock/RegistrationLockDialog.java
@@ -64,6 +64,9 @@ public final class RegistrationLockDialog {
     if (!TextSecurePreferences.isV1RegistrationLockEnabled(context) && !SignalStore.kbsValues().isV2RegistrationLockEnabled()) {
       return;
     }
+    if (TextSecurePreferences.isPinV2ReminderDisabled(ApplicationDependencies.getApplication())) {
+      return;
+    }
 
     if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) {
       return;

--- a/app/src/main/java/org/thoughtcrime/securesms/megaphone/Megaphones.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/megaphone/Megaphones.java
@@ -20,6 +20,7 @@ import org.thoughtcrime.securesms.lock.v2.KbsMigrationActivity;
 import org.thoughtcrime.securesms.lock.v2.PinUtil;
 import org.thoughtcrime.securesms.logging.Log;
 import org.thoughtcrime.securesms.util.FeatureFlags;
+import org.thoughtcrime.securesms.util.TextSecurePreferences;
 
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -48,7 +49,7 @@ public final class Megaphones {
   static @Nullable Megaphone getNextMegaphone(@NonNull Context context, @NonNull Map<Event, MegaphoneRecord> records) {
     long currentTime = System.currentTimeMillis();
 
-    List<Megaphone> megaphones = Stream.of(buildDisplayOrder())
+    List<Megaphone> megaphones = Stream.of(buildDisplayOrder(context))
                                        .filter(e -> {
                                          MegaphoneRecord   record = Objects.requireNonNull(records.get(e.getKey()));
                                          MegaphoneSchedule schedule = e.getValue();
@@ -78,11 +79,13 @@ public final class Megaphones {
    * This is when you would hide certain megaphones based on {@link FeatureFlags}. You could
    * conditionally set a {@link ForeverSchedule} set to false for disabled features.
    */
-  private static Map<Event, MegaphoneSchedule> buildDisplayOrder() {
+  private static Map<Event, MegaphoneSchedule> buildDisplayOrder(Context context) {
     return new LinkedHashMap<Event, MegaphoneSchedule>() {{
       put(Event.REACTIONS, new ForeverSchedule(true));
       put(Event.PINS_FOR_ALL, new PinsForAllSchedule());
-      put(Event.PIN_REMINDER, new SignalPinReminderSchedule());
+      if (!TextSecurePreferences.isPinV2ReminderDisabled(context)) {
+        put(Event.PIN_REMINDER, new SignalPinReminderSchedule());
+      }
     }};
   }
 

--- a/app/src/main/java/org/thoughtcrime/securesms/megaphone/SignalPinReminderSchedule.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/megaphone/SignalPinReminderSchedule.java
@@ -1,13 +1,18 @@
 package org.thoughtcrime.securesms.megaphone;
 
+import org.thoughtcrime.securesms.dependencies.ApplicationDependencies;
 import org.thoughtcrime.securesms.keyvalue.SignalStore;
 import org.thoughtcrime.securesms.util.FeatureFlags;
+import org.thoughtcrime.securesms.util.TextSecurePreferences;
 
 final class SignalPinReminderSchedule implements MegaphoneSchedule {
 
   @Override
   public boolean shouldDisplay(int seenCount, long lastSeen, long firstVisible, long currentTime) {
     if (!SignalStore.kbsValues().isV2RegistrationLockEnabled()) {
+      return false;
+    }
+    if (TextSecurePreferences.isPinV2ReminderDisabled(ApplicationDependencies.getApplication())) {
       return false;
     }
 

--- a/app/src/main/java/org/thoughtcrime/securesms/util/TextSecurePreferences.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/util/TextSecurePreferences.java
@@ -187,6 +187,16 @@ public class TextSecurePreferences {
 
   private static final String STORAGE_MANIFEST_VERSION = "pref_storage_manifest_version";
 
+  public static final String DISABLE_PINV2_MEMINDERS = "pref_signal_disable_pinv2_reminders";
+
+  public static boolean isPinV2ReminderDisabled(@NonNull Context context) {
+    return getBooleanPreference(context, DISABLE_PINV2_MEMINDERS, false);
+  }
+
+  public static void setPinV2ReminderDisabled(@NonNull Context context, boolean value) {
+    setBooleanPreference(context, DISABLE_PINV2_MEMINDERS, value);
+  }
+
   public static boolean isScreenLockEnabled(@NonNull Context context) {
     return isPassphraseLockEnabled(context);
   }

--- a/app/src/main/java/org/thoughtcrime/securesms/util/TextSecurePreferences.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/util/TextSecurePreferences.java
@@ -187,14 +187,14 @@ public class TextSecurePreferences {
 
   private static final String STORAGE_MANIFEST_VERSION = "pref_storage_manifest_version";
 
-  public static final String DISABLE_PINV2_MEMINDERS = "pref_signal_disable_pinv2_reminders";
+  public static final String DISABLE_PINV2_REMINDERS = "pref_signal_disable_pinv2_reminders";
 
   public static boolean isPinV2ReminderDisabled(@NonNull Context context) {
-    return getBooleanPreference(context, DISABLE_PINV2_MEMINDERS, false);
+    return getBooleanPreference(context, DISABLE_PINV2_REMINDERS, false);
   }
 
   public static void setPinV2ReminderDisabled(@NonNull Context context, boolean value) {
-    setBooleanPreference(context, DISABLE_PINV2_MEMINDERS, value);
+    setBooleanPreference(context, DISABLE_PINV2_REMINDERS, value);
   }
 
   public static boolean isScreenLockEnabled(@NonNull Context context) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1874,6 +1874,8 @@
     <string name="preferences_app_protection__change">Change</string>
     <string name="preferences_app_protection__create">Create</string>
     <string name="preferences_app_protection__your_pin_adds_an_extra_layer_of_security_and_backs">Your PIN adds an extra layer of security and backs up your account. You\'ll be asked for it when you register your phone number with Signal. If you forget your PIN, you\'ll be locked out of your account for 7 days.</string>
+    <string name="preferences_app_protection__disable_pinv2_reminders">Disable PIN reminders</string>
+    <string name="preferences_app_protection__disable_pinv2_reminders_summary">Disable PIN reminder requests</string>    
     <string name="AppProtectionPreferenceFragment_none">None</string>
     <string name="registration_activity__the_registration_lock_pin_is_not_the_same_as_the_sms_verification_code_you_just_received_please_enter_the_pin_you_previously_configured_in_the_application">The Registration Lock PIN is not the same as the SMS verification code you just received. Please enter the PIN you previously configured in the application.</string>
     <string name="registration_activity__registration_lock_pin">Registration Lock PIN</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1875,7 +1875,7 @@
     <string name="preferences_app_protection__create">Create</string>
     <string name="preferences_app_protection__your_pin_adds_an_extra_layer_of_security_and_backs">Your PIN adds an extra layer of security and backs up your account. You\'ll be asked for it when you register your phone number with Signal. If you forget your PIN, you\'ll be locked out of your account for 7 days.</string>
     <string name="preferences_app_protection__disable_pinv2_reminders">Disable PIN reminders</string>
-    <string name="preferences_app_protection__disable_pinv2_reminders_summary">Disable PIN reminder requests</string>    
+    <string name="preferences_app_protection__disable_pinv2_reminders_summary">Do not prompt to enter your PIN periodically</string>    
     <string name="AppProtectionPreferenceFragment_none">None</string>
     <string name="registration_activity__the_registration_lock_pin_is_not_the_same_as_the_sms_verification_code_you_just_received_please_enter_the_pin_you_previously_configured_in_the_application">The Registration Lock PIN is not the same as the SMS verification code you just received. Please enter the PIN you previously configured in the application.</string>
     <string name="registration_activity__registration_lock_pin">Registration Lock PIN</string>

--- a/app/src/main/res/xml/preferences_app_protection.xml
+++ b/app/src/main/res/xml/preferences_app_protection.xml
@@ -108,6 +108,12 @@
             android:key="pref_kbs_change"
             android:title="@string/preferences_app_protection__pin"
             android:summary="@string/preferences_app_protection__your_pin_adds_an_extra_layer_of_security_and_backs" />
+
+        <org.thoughtcrime.securesms.components.SwitchPreferenceCompat
+            android:key="pref_signal_disable_pinv2_reminders"
+            android:defaultValue="false"
+            android:title="@string/preferences_app_protection__disable_pinv2_reminders"
+            android:summary="@string/preferences_app_protection__disable_pinv2_reminders_summary"/>
     </PreferenceCategory>
 
 </PreferenceScreen>


### PR DESCRIPTION
This extra option is shown when a v2 PIN set and it prevents the weekly reminder to show.

One small issue: if a reminder is already shown you have to exit Molly (locking is not necessary, just exit the main activity) and reopen it for the reminder to go away. I did not fix this because it would complicate the code a lot for an option that is probably set-once and forget.