### PR TITLE
Remove arbitary 3 hour limit for sending Remote Delete Requests

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/util/RemoteDeleteUtil.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/util/RemoteDeleteUtil.java
@@ -13,7 +13,7 @@ import java.util.concurrent.TimeUnit;
 public final class RemoteDeleteUtil {
 
   private static final long RECEIVE_THRESHOLD = TimeUnit.DAYS.toMillis(1);
-  private static final long SEND_THRESHOLD    = TimeUnit.HOURS.toMillis(3);
+  private static final long SEND_THRESHOLD    = TimeUnit.DAYS.toMillis(1);
 
   private RemoteDeleteUtil() {}
 


### PR DESCRIPTION
Allow for 1 day to send a Remote Deletion Request, sets the `SEND_THRESHOLD` to be the same as the `RECEIVE_THRESHOLD`.

I'm not sure why there are Deletion Thresholds in the first place.

TL;DR gives you 1 day to redact/delete messages as apposed to the stock 3 hours.