### PR TITLE
Minor grammar correction in strings2.xml

### DIFF
--- a/app/src/main/res/values/strings2.xml
+++ b/app/src/main/res/values/strings2.xml
@@ -31,7 +31,7 @@
     <string name="preferences_network__online">Online</string>
     <string name="ApplicationPreferencesActivity_privacy_summary_passphrase_registration_locks">Database encryption %1$s, Registration lock %2$s</string>
     <string name="WipeMemoryService_secure_wipe_in_progress">Secure wipe in progress</string>
-    <string name="WipeMemoryService_clearing_unencrypted_data_remain_in_ram">Clearing unencrypted data remaining in RAM</string>
+    <string name="WipeMemoryService_clearing_unencrypted_data_remain_in_ram">Clearing unencrypted data in RAM</string>
     <string name="PrivacySettingsFragment_data_at_rest">Data at rest</string>
     <string name="AppProtectionPreferenceFragment_instant">Instant</string>
     <string name="PassphraseCreateActivity_now_you_can_set_a_passphrase_to_encrypt_the_database">Now you can set a passphrase to encrypt the database. Until it\'s unlocked, Molly cannot receive notifications or calls. This helps protect data on lost or stolen devices.</string>

--- a/app/src/main/res/values/strings2.xml
+++ b/app/src/main/res/values/strings2.xml
@@ -31,7 +31,7 @@
     <string name="preferences_network__online">Online</string>
     <string name="ApplicationPreferencesActivity_privacy_summary_passphrase_registration_locks">Database encryption %1$s, Registration lock %2$s</string>
     <string name="WipeMemoryService_secure_wipe_in_progress">Secure wipe in progress</string>
-    <string name="WipeMemoryService_clearing_unencrypted_data_remain_in_ram">Clearing unencrypted data remain in RAM</string>
+    <string name="WipeMemoryService_clearing_unencrypted_data_remain_in_ram">Clearing unencrypted data remaining in RAM</string>
     <string name="PrivacySettingsFragment_data_at_rest">Data at rest</string>
     <string name="AppProtectionPreferenceFragment_instant">Instant</string>
     <string name="PassphraseCreateActivity_now_you_can_set_a_passphrase_to_encrypt_the_database">Now you can set a passphrase to encrypt the database. Until it\'s unlocked, Molly cannot receive notifications or calls. This helps protect data on lost or stolen devices.</string>


### PR DESCRIPTION
Minor grammar gerund correction (change "remain" to "remaining" in "Clearing unencrypted data remain in RAM" message)