### PR TITLE
Allow registering as a linked device

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/ApplicationContext.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/ApplicationContext.java
@@ -68,6 +68,7 @@ import org.thoughtcrime.securesms.jobs.PreKeysSyncJob;
 import org.thoughtcrime.securesms.jobs.ProfileUploadJob;
 import org.thoughtcrime.securesms.jobs.RefreshAttributesJob;
 import org.thoughtcrime.securesms.jobs.RefreshSvrCredentialsJob;
+import org.thoughtcrime.securesms.jobs.RefreshOwnProfileJob;
 import org.thoughtcrime.securesms.jobs.RetrieveProfileJob;
 import org.thoughtcrime.securesms.jobs.RetrieveRemoteAnnouncementsJob;
 import org.thoughtcrime.securesms.jobs.StoryOnboardingDownloadJob;
@@ -565,9 +566,14 @@ public class ApplicationContext extends MultiDexApplication implements AppForegr
   }
 
   private void ensureProfileUploaded() {
-    if (SignalStore.account().isRegistered() && !SignalStore.registrationValues().hasUploadedProfile() && !Recipient.self().getProfileName().isEmpty()) {
-      Log.w(TAG, "User has a profile, but has not uploaded one. Uploading now.");
-      ApplicationDependencies.getJobManager().add(new ProfileUploadJob());
+    if (SignalStore.account().isRegistered()) {
+      if (SignalStore.registrationValues().needDownloadProfileOrAvatar()) {
+        Log.w(TAG, "User has linked a device, but has not yet downloaded the profile. Downloading now.");
+        ApplicationDependencies.getJobManager().add(new RefreshOwnProfileJob());
+      } else if (!SignalStore.registrationValues().hasUploadedProfile() && !Recipient.self().getProfileName().isEmpty()) {
+        Log.w(TAG, "User has a profile, but has not uploaded one. Uploading now.");
+        ApplicationDependencies.getJobManager().add(new ProfileUploadJob());
+      }
     }
   }
 

--- a/app/src/main/java/org/thoughtcrime/securesms/DeviceListFragment.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/DeviceListFragment.java
@@ -20,6 +20,8 @@ import androidx.fragment.app.ListFragment;
 import androidx.loader.app.LoaderManager;
 import androidx.loader.content.Loader;
 
+import com.annimon.stream.Stream;
+
 import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 import com.google.android.material.floatingactionbutton.FloatingActionButton;
 
@@ -31,6 +33,7 @@ import org.thoughtcrime.securesms.keyvalue.SignalStore;
 import org.thoughtcrime.securesms.util.TextSecurePreferences;
 import org.thoughtcrime.securesms.util.task.ProgressDialogAsyncTask;
 import org.whispersystems.signalservice.api.SignalServiceAccountManager;
+import org.whispersystems.signalservice.api.push.SignalServiceAddress;
 
 import java.io.IOException;
 import java.util.List;
@@ -45,7 +48,6 @@ public class DeviceListFragment extends ListFragment
 
   private SignalServiceAccountManager accountManager;
   private Locale                      locale;
-  private View                        empty;
   private View                        progressContainer;
   private FloatingActionButton        addDeviceButton;
   private Button.OnClickListener      addDeviceButtonListener;
@@ -66,10 +68,13 @@ public class DeviceListFragment extends ListFragment
   public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle bundle) {
     View view = inflater.inflate(R.layout.device_list_fragment, container, false);
 
-    this.empty             = view.findViewById(R.id.empty);
     this.progressContainer = view.findViewById(R.id.progress_container);
     this.addDeviceButton   = view.findViewById(R.id.add_device);
-    this.addDeviceButton.setOnClickListener(this);
+    if (SignalStore.account().isPrimaryDevice()) {
+      this.addDeviceButton.setOnClickListener(this);
+    } else {
+      this.addDeviceButton.setVisibility(View.GONE);
+    }
 
     return view;
   }
@@ -87,7 +92,6 @@ public class DeviceListFragment extends ListFragment
 
   @Override
   public @NonNull Loader<List<Device>> onCreateLoader(int id, Bundle args) {
-    empty.setVisibility(View.GONE);
     progressContainer.setVisibility(View.VISIBLE);
 
     return new DeviceListLoader(getActivity(), accountManager);
@@ -102,16 +106,11 @@ public class DeviceListFragment extends ListFragment
       return;
     }
 
-    setListAdapter(new DeviceListAdapter(getActivity(), R.layout.device_list_item_view, data, locale));
+    setListAdapter(new DeviceListAdapter(getActivity(), R.layout.device_list_item_view, data, locale, SignalStore.account().getDeviceId()));
 
-    if (data.isEmpty()) {
-      empty.setVisibility(View.VISIBLE);
-      TextSecurePreferences.setMultiDevice(getActivity(), false);
-      SignalStore.misc().setHasLinkedDevices(false);
-    } else {
-      SignalStore.misc().setHasLinkedDevices(true);
-      empty.setVisibility(View.GONE);
-    }
+    boolean hasLinkedDevices = Stream.of(data).noneMatch(d -> d.getId() != SignalServiceAddress.DEFAULT_DEVICE_ID);
+    TextSecurePreferences.setMultiDevice(getActivity(), SignalStore.account().isLinkedDevice() || hasLinkedDevices);
+    SignalStore.misc().setHasLinkedDevices(hasLinkedDevices);
   }
 
   @Override
@@ -123,6 +122,10 @@ public class DeviceListFragment extends ListFragment
   public void onItemClick(AdapterView<?> parent, View view, int position, long id) {
     final String deviceName = ((DeviceListItem)view).getDeviceName();
     final long   deviceId   = ((DeviceListItem)view).getDeviceId();
+    if (deviceId == SignalServiceAddress.DEFAULT_DEVICE_ID || deviceId == SignalStore.account().getDeviceId()) {
+      // Sanity check
+      return;
+    }
 
     AlertDialog.Builder builder = new MaterialAlertDialogBuilder(requireActivity());
     builder.setTitle(getString(R.string.DeviceListActivity_unlink_s, deviceName));
@@ -182,11 +185,13 @@ public class DeviceListFragment extends ListFragment
 
     private final int    resource;
     private final Locale locale;
+    private final long   thisDeviceId;
 
-    public DeviceListAdapter(Context context, int resource, List<Device> objects, Locale locale) {
+    public DeviceListAdapter(Context context, int resource, List<Device> objects, Locale locale, long thisDeviceId) {
       super(context, resource, objects);
       this.resource = resource;
       this.locale = locale;
+      this.thisDeviceId = thisDeviceId;
     }
 
     @Override
@@ -195,9 +200,15 @@ public class DeviceListFragment extends ListFragment
         convertView = ((Activity)getContext()).getLayoutInflater().inflate(resource, parent, false);
       }
 
-      ((DeviceListItem)convertView).set(getItem(position), locale);
+      ((DeviceListItem)convertView).set(getItem(position), locale, thisDeviceId);
 
       return convertView;
+    }
+
+    @Override
+    public boolean isEnabled(int position) {
+      long deviceId = getItem(position).getId();
+      return deviceId != SignalServiceAddress.DEFAULT_DEVICE_ID && deviceId != thisDeviceId;
     }
   }
 }

--- a/app/src/main/java/org/thoughtcrime/securesms/DeviceListItem.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/DeviceListItem.java
@@ -5,9 +5,11 @@ import android.text.TextUtils;
 import android.util.AttributeSet;
 import android.widget.LinearLayout;
 import android.widget.TextView;
+import android.view.View;
 
 import org.thoughtcrime.securesms.devicelist.Device;
 import org.thoughtcrime.securesms.util.DateUtils;
+import org.whispersystems.signalservice.api.push.SignalServiceAddress;
 
 import java.util.Locale;
 
@@ -15,6 +17,8 @@ public class DeviceListItem extends LinearLayout {
 
   private long     deviceId;
   private TextView name;
+  private View     primary;
+  private View     thisDevice;
   private TextView created;
   private TextView lastActive;
 
@@ -30,15 +34,19 @@ public class DeviceListItem extends LinearLayout {
   public void onFinishInflate() {
     super.onFinishInflate();
     this.name       = (TextView) findViewById(R.id.name);
+    this.primary    = findViewById(R.id.primary);
+    this.thisDevice = findViewById(R.id.this_device);
     this.created    = (TextView) findViewById(R.id.created);
     this.lastActive = (TextView) findViewById(R.id.active);
   }
 
-  public void set(Device deviceInfo, Locale locale) {
-    if (TextUtils.isEmpty(deviceInfo.getName())) this.name.setText(R.string.DeviceListItem_unnamed_device);
+  public void set(Device deviceInfo, Locale locale, long thisDeviceId) {
+    if (TextUtils.isEmpty(deviceInfo.getName())) this.name.setText(getContext().getString(R.string.DeviceListItem_device_d, deviceInfo.getId()));
     else                                         this.name.setText(deviceInfo.getName());
 
-    this.created.setText(getContext().getString(R.string.DeviceListItem_linked_s,
+    this.deviceId = deviceInfo.getId();
+
+    this.created.setText(getContext().getString(this.deviceId == SignalServiceAddress.DEFAULT_DEVICE_ID ? R.string.DeviceListItem_registered_s : R.string.DeviceListItem_linked_s,
                                                 DateUtils.getDayPrecisionTimeSpanString(getContext(),
                                                                                         locale,
                                                                                         deviceInfo.getCreated())));
@@ -48,7 +56,8 @@ public class DeviceListItem extends LinearLayout {
                                                                                            locale,
                                                                                            deviceInfo.getLastSeen())));
 
-    this.deviceId = deviceInfo.getId();
+    this.primary.setVisibility(this.deviceId == SignalServiceAddress.DEFAULT_DEVICE_ID ? View.VISIBLE : View.GONE);
+    this.thisDevice.setVisibility(this.deviceId == thisDeviceId ? View.VISIBLE : View.GONE);
   }
 
   public long getDeviceId() {

--- a/app/src/main/java/org/thoughtcrime/securesms/components/settings/app/account/AccountSettingsFragment.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/components/settings/app/account/AccountSettingsFragment.kt
@@ -54,7 +54,7 @@ class AccountSettingsFragment : DSLSettingsFragment(R.string.AccountSettingsFrag
       @Suppress("DEPRECATION")
       clickPref(
         title = DSLSettingsText.from(if (state.hasPin) R.string.preferences_app_protection__change_your_pin else R.string.preferences_app_protection__create_a_pin),
-        isEnabled = state.isDeprecatedOrUnregistered(),
+        isEnabled = state.isDeprecatedOrUnregistered() && SignalStore.account().isPrimaryDevice,
         onClick = {
           if (state.hasPin) {
             startActivityForResult(CreateSvrPinActivity.getIntentForPinChangeFromSettings(requireContext()), CreateSvrPinActivity.REQUEST_NEW_PIN)
@@ -67,8 +67,8 @@ class AccountSettingsFragment : DSLSettingsFragment(R.string.AccountSettingsFrag
       switchPref(
         title = DSLSettingsText.from(R.string.preferences_app_protection__pin_reminders),
         summary = DSLSettingsText.from(R.string.AccountSettingsFragment__youll_be_asked_less_frequently),
-        isChecked = state.hasPin && state.pinRemindersEnabled,
-        isEnabled = state.hasPin && state.isDeprecatedOrUnregistered(),
+        isChecked = state.hasPin && state.pinRemindersEnabled && SignalStore.account().isPrimaryDevice,
+        isEnabled = state.hasPin && state.isDeprecatedOrUnregistered() && SignalStore.account().isPrimaryDevice,
         onClick = {
           setPinRemindersEnabled(!state.pinRemindersEnabled)
         }
@@ -77,8 +77,8 @@ class AccountSettingsFragment : DSLSettingsFragment(R.string.AccountSettingsFrag
       switchPref(
         title = DSLSettingsText.from(R.string.preferences_app_protection__registration_lock),
         summary = DSLSettingsText.from(R.string.AccountSettingsFragment__require_your_signal_pin),
-        isChecked = state.registrationLockEnabled,
-        isEnabled = state.hasPin && state.isDeprecatedOrUnregistered(),
+        isChecked = state.registrationLockEnabled && SignalStore.account().isPrimaryDevice,
+        isEnabled = state.hasPin && state.isDeprecatedOrUnregistered() && SignalStore.account().isPrimaryDevice,
         onClick = {
           setRegistrationLockEnabled(!state.registrationLockEnabled)
         }
@@ -86,11 +86,17 @@ class AccountSettingsFragment : DSLSettingsFragment(R.string.AccountSettingsFrag
 
       clickPref(
         title = DSLSettingsText.from(R.string.preferences__advanced_pin_settings),
-        isEnabled = state.isDeprecatedOrUnregistered(),
+        isEnabled = state.isDeprecatedOrUnregistered() && SignalStore.account().isPrimaryDevice,
         onClick = {
           Navigation.findNavController(requireView()).safeNavigate(R.id.action_accountSettingsFragment_to_advancedPinSettingsActivity)
         }
       )
+
+      if (SignalStore.account().isLinkedDevice) {
+        textPref(
+          summary = DSLSettingsText.from(R.string.preferences__primary_only)
+        )
+      }
 
       dividerPref()
 
@@ -99,7 +105,7 @@ class AccountSettingsFragment : DSLSettingsFragment(R.string.AccountSettingsFrag
       if (SignalStore.account().isRegistered) {
         clickPref(
           title = DSLSettingsText.from(R.string.AccountSettingsFragment__change_phone_number),
-          isEnabled = state.isDeprecatedOrUnregistered(),
+          isEnabled = state.isDeprecatedOrUnregistered() && SignalStore.account().isPrimaryDevice,
           onClick = {
             Navigation.findNavController(requireView()).safeNavigate(R.id.action_accountSettingsFragment_to_changePhoneNumberFragment)
           }

--- a/app/src/main/java/org/thoughtcrime/securesms/components/settings/app/chats/ChatsSettingsFragment.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/components/settings/app/chats/ChatsSettingsFragment.kt
@@ -7,6 +7,7 @@ import org.thoughtcrime.securesms.components.settings.DSLConfiguration
 import org.thoughtcrime.securesms.components.settings.DSLSettingsFragment
 import org.thoughtcrime.securesms.components.settings.DSLSettingsText
 import org.thoughtcrime.securesms.components.settings.configure
+import org.thoughtcrime.securesms.keyvalue.SignalStore
 import org.thoughtcrime.securesms.util.adapter.mapping.MappingAdapter
 import org.thoughtcrime.securesms.util.navigation.safeNavigate
 
@@ -33,10 +34,17 @@ class ChatsSettingsFragment : DSLSettingsFragment(R.string.preferences_chats__ch
         title = DSLSettingsText.from(R.string.preferences__generate_link_previews),
         summary = DSLSettingsText.from(R.string.preferences__retrieve_link_previews_from_websites_for_messages),
         isChecked = state.generateLinkPreviews,
+        isEnabled = SignalStore.account().isPrimaryDevice,
         onClick = {
           viewModel.setGenerateLinkPreviewsEnabled(!state.generateLinkPreviews)
         }
       )
+
+      if (SignalStore.account().isLinkedDevice) {
+        textPref(
+          summary = DSLSettingsText.from(R.string.preferences__primary_only)
+        )
+      }
 
       switchPref(
         title = DSLSettingsText.from(R.string.preferences__pref_use_address_book_photos),

--- a/app/src/main/java/org/thoughtcrime/securesms/components/settings/app/chats/ChatsSettingsViewModel.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/components/settings/app/chats/ChatsSettingsViewModel.kt
@@ -35,6 +35,9 @@ class ChatsSettingsViewModel @JvmOverloads constructor(
   }
 
   fun setGenerateLinkPreviewsEnabled(enabled: Boolean) {
+    if (SignalStore.account().isLinkedDevice) {
+      return
+    }
     store.update { it.copy(generateLinkPreviews = enabled) }
     SignalStore.settings().isLinkPreviewsEnabled = enabled
     repository.syncLinkPreviewsState()

--- a/app/src/main/java/org/thoughtcrime/securesms/components/settings/app/privacy/PrivacySettingsFragment.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/components/settings/app/privacy/PrivacySettingsFragment.kt
@@ -30,6 +30,7 @@ import org.thoughtcrime.securesms.components.settings.DSLSettingsText
 import org.thoughtcrime.securesms.components.settings.PreferenceModel
 import org.thoughtcrime.securesms.components.settings.PreferenceViewHolder
 import org.thoughtcrime.securesms.components.settings.configure
+import org.thoughtcrime.securesms.keyvalue.SignalStore
 import org.thoughtcrime.securesms.preferences.widgets.PassphraseLockTriggerPreference
 import org.thoughtcrime.securesms.util.CommunicationActions
 import org.thoughtcrime.securesms.util.ConversationUtil
@@ -189,6 +190,7 @@ class PrivacySettingsFragment : DSLSettingsFragment(R.string.preferences__privac
         title = DSLSettingsText.from(R.string.preferences__read_receipts),
         summary = DSLSettingsText.from(R.string.preferences__if_read_receipts_are_disabled_you_wont_be_able_to_see_read_receipts),
         isChecked = state.readReceipts,
+        isEnabled = SignalStore.account().isPrimaryDevice,
         onClick = {
           viewModel.setReadReceiptsEnabled(!state.readReceipts)
         }
@@ -198,10 +200,17 @@ class PrivacySettingsFragment : DSLSettingsFragment(R.string.preferences__privac
         title = DSLSettingsText.from(R.string.preferences__typing_indicators),
         summary = DSLSettingsText.from(R.string.preferences__if_typing_indicators_are_disabled_you_wont_be_able_to_see_typing_indicators),
         isChecked = state.typingIndicators,
+        isEnabled = SignalStore.account().isPrimaryDevice,
         onClick = {
           viewModel.setTypingIndicatorsEnabled(!state.typingIndicators)
         }
       )
+
+      if (SignalStore.account().isLinkedDevice) {
+        textPref(
+          summary = DSLSettingsText.from(R.string.preferences__primary_only)
+        )
+      }
 
       dividerPref()
 

--- a/app/src/main/java/org/thoughtcrime/securesms/components/settings/app/privacy/PrivacySettingsViewModel.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/components/settings/app/privacy/PrivacySettingsViewModel.kt
@@ -35,12 +35,18 @@ class PrivacySettingsViewModel(
   }
 
   fun setReadReceiptsEnabled(enabled: Boolean) {
+    if (SignalStore.account().isLinkedDevice) {
+      return
+    }
     sharedPreferences.edit().putBoolean(TextSecurePreferences.READ_RECEIPTS_PREF, enabled).apply()
     repository.syncReadReceiptState()
     refresh()
   }
 
   fun setTypingIndicatorsEnabled(enabled: Boolean) {
+    if (SignalStore.account().isLinkedDevice) {
+      return
+    }
     sharedPreferences.edit().putBoolean(TextSecurePreferences.TYPING_INDICATORS, enabled).apply()
     repository.syncTypingIndicatorsState()
     refresh()

--- a/app/src/main/java/org/thoughtcrime/securesms/components/settings/app/privacy/advanced/AdvancedPrivacySettingsFragment.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/components/settings/app/privacy/advanced/AdvancedPrivacySettingsFragment.kt
@@ -183,9 +183,16 @@ class AdvancedPrivacySettingsFragment : DSLSettingsFragment(R.string.preferences
             .append(statusIcon)
         ),
         summary = DSLSettingsText.from(R.string.AdvancedPrivacySettingsFragment__show_an_icon),
-        isChecked = state.showSealedSenderStatusIcon
+        isChecked = state.showSealedSenderStatusIcon,
+        isEnabled = SignalStore.account().isPrimaryDevice
       ) {
         viewModel.setShowStatusIconForSealedSender(!state.showSealedSenderStatusIcon)
+      }
+
+      if (SignalStore.account().isLinkedDevice) {
+        textPref(
+          summary = DSLSettingsText.from(R.string.preferences__primary_only)
+        )
       }
 
       switchPref(

--- a/app/src/main/java/org/thoughtcrime/securesms/components/settings/app/privacy/advanced/AdvancedPrivacySettingsViewModel.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/components/settings/app/privacy/advanced/AdvancedPrivacySettingsViewModel.kt
@@ -63,6 +63,9 @@ class AdvancedPrivacySettingsViewModel(
   }
 
   fun setShowStatusIconForSealedSender(enabled: Boolean) {
+    if (SignalStore.account().isLinkedDevice) {
+      return
+    }
     sharedPreferences.edit().putBoolean(TextSecurePreferences.SHOW_UNIDENTIFIED_DELIVERY_INDICATORS, enabled).apply()
     repository.syncShowSealedSenderIconState()
     refresh()

--- a/app/src/main/java/org/thoughtcrime/securesms/database/loaders/DeviceListLoader.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/database/loaders/DeviceListLoader.java
@@ -21,7 +21,6 @@ import org.thoughtcrime.securesms.util.AsyncLoader;
 import org.thoughtcrime.securesms.util.Base64;
 import org.whispersystems.signalservice.api.SignalServiceAccountManager;
 import org.whispersystems.signalservice.api.messages.multidevice.DeviceInfo;
-import org.whispersystems.signalservice.api.push.SignalServiceAddress;
 
 import java.io.IOException;
 import java.security.GeneralSecurityException;
@@ -53,7 +52,6 @@ public class DeviceListLoader extends AsyncLoader<List<Device>> {
   public List<Device> loadInBackground() {
     try {
       List<Device> devices = Stream.of(accountManager.getDevices())
-                                   .filter(d -> d.getId() != SignalServiceAddress.DEFAULT_DEVICE_ID)
                                    .map(this::mapToDevice)
                                    .toList();
 

--- a/app/src/main/java/org/thoughtcrime/securesms/jobs/AllDataSyncRequestJob.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/jobs/AllDataSyncRequestJob.java
@@ -1,0 +1,74 @@
+package org.thoughtcrime.securesms.jobs;
+
+import androidx.annotation.NonNull;
+
+import org.signal.core.util.logging.Log;
+import org.thoughtcrime.securesms.crypto.UnidentifiedAccessUtil;
+import org.thoughtcrime.securesms.dependencies.ApplicationDependencies;
+import org.thoughtcrime.securesms.jobmanager.Job;
+import org.thoughtcrime.securesms.jobmanager.impl.NetworkConstraint;
+import org.whispersystems.signalservice.api.SignalServiceMessageSender;
+import org.whispersystems.signalservice.api.crypto.UnidentifiedAccessPair;
+import org.whispersystems.signalservice.api.crypto.UntrustedIdentityException;
+import org.whispersystems.signalservice.api.messages.multidevice.RequestMessage;
+import org.whispersystems.signalservice.api.messages.multidevice.SignalServiceSyncMessage;
+import org.whispersystems.signalservice.api.push.exceptions.PushNetworkException;
+import org.whispersystems.signalservice.internal.push.SignalServiceProtos;
+
+import java.io.IOException;
+import java.util.Optional;
+
+public class AllDataSyncRequestJob extends BaseJob {
+
+  public static final String KEY = "AllDataSyncRequestJob";
+
+  private static final String TAG = Log.tag(AllDataSyncRequestJob.class);
+
+  public AllDataSyncRequestJob()
+  {
+    this(new Job.Parameters.Builder()
+                           .setQueue("AllDataSyncRequestJob")
+                           .addConstraint(NetworkConstraint.KEY)
+                           .setMaxAttempts(10)
+                           .build());
+  }
+
+  private AllDataSyncRequestJob(@NonNull Job.Parameters parameters) {
+    super(parameters);
+  }
+
+  @Override
+  public @NonNull byte[] serialize() {
+    return null;
+  }
+
+  @Override
+  public @NonNull String getFactoryKey() {
+    return KEY;
+  }
+
+  @Override
+  public void onRun() throws IOException, UntrustedIdentityException {
+    SignalServiceMessageSender signalServiceMessageSender = ApplicationDependencies.getSignalServiceMessageSender();
+    Optional<UnidentifiedAccessPair> accessForSync = UnidentifiedAccessUtil.getAccessForSync(context);
+    signalServiceMessageSender.sendSyncMessage(SignalServiceSyncMessage.forRequest(RequestMessage.forType(SignalServiceProtos.SyncMessage.Request.Type.CONTACTS)), accessForSync);
+    signalServiceMessageSender.sendSyncMessage(SignalServiceSyncMessage.forRequest(RequestMessage.forType(SignalServiceProtos.SyncMessage.Request.Type.BLOCKED)), accessForSync);
+    signalServiceMessageSender.sendSyncMessage(SignalServiceSyncMessage.forRequest(RequestMessage.forType(SignalServiceProtos.SyncMessage.Request.Type.CONFIGURATION)), accessForSync);
+    signalServiceMessageSender.sendSyncMessage(SignalServiceSyncMessage.forRequest(RequestMessage.forType(SignalServiceProtos.SyncMessage.Request.Type.KEYS)), accessForSync);
+  }
+
+  @Override
+  public boolean onShouldRetry(@NonNull Exception exception) {
+    return exception instanceof PushNetworkException;
+  }
+
+  @Override
+  public void onFailure() {}
+
+  public static final class Factory implements Job.Factory<AllDataSyncRequestJob> {
+    @Override
+    public @NonNull AllDataSyncRequestJob create(@NonNull Parameters parameters, @NonNull byte[] serializedData) {
+      return new AllDataSyncRequestJob(parameters);
+    }
+  }
+}

--- a/app/src/main/java/org/thoughtcrime/securesms/jobs/JobManagerFactories.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/jobs/JobManagerFactories.java
@@ -90,6 +90,7 @@ public final class JobManagerFactories {
   public static Map<String, Job.Factory> getJobFactories(@NonNull Application application) {
     return new HashMap<String, Job.Factory>() {{
       put(AccountConsistencyWorkerJob.KEY,           new AccountConsistencyWorkerJob.Factory());
+      put(AllDataSyncRequestJob.KEY,                 new AllDataSyncRequestJob.Factory());
       put(AttachmentCopyJob.KEY,                     new AttachmentCopyJob.Factory());
       put(AttachmentDownloadJob.KEY,                 new AttachmentDownloadJob.Factory());
       put(AttachmentUploadJob.KEY,                   new AttachmentUploadJob.Factory());

--- a/app/src/main/java/org/thoughtcrime/securesms/jobs/RefreshAttributesJob.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/jobs/RefreshAttributesJob.java
@@ -102,7 +102,7 @@ public class RefreshAttributesJob extends BaseJob {
     String deviceName = SignalStore.account().getDeviceName();
     byte[] encryptedDeviceName = (deviceName == null) ? null : DeviceNameCipher.encryptDeviceName(deviceName.getBytes(StandardCharsets.UTF_8), SignalStore.account().getAciIdentityKey());
 
-    AccountAttributes.Capabilities capabilities = AppCapabilities.getCapabilities(svrValues.hasPin() && !svrValues.hasOptedOut());
+    AccountAttributes.Capabilities capabilities = AppCapabilities.getCapabilities((svrValues.hasPin() && !svrValues.hasOptedOut()) || SignalStore.storageService().hasStorageKeyFromPrimary());
     Log.i(TAG, "Calling setAccountAttributes() reglockV2? " + !TextUtils.isEmpty(registrationLockV2) + ", pin? " + svrValues.hasPin() +
                "\n    Recovery password? " + !TextUtils.isEmpty(recoveryPassword) +
                "\n    Phone number discoverable : " + phoneNumberDiscoverable +

--- a/app/src/main/java/org/thoughtcrime/securesms/jobs/RefreshOwnProfileJob.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/jobs/RefreshOwnProfileJob.java
@@ -98,6 +98,8 @@ public class RefreshOwnProfileJob extends BaseJob {
     ProfileAndCredential profileAndCredential = ProfileUtil.retrieveProfileSync(context, self, getRequestType(self), false);
     SignalServiceProfile profile              = profileAndCredential.getProfile();
 
+    SignalStore.registrationValues().clearNeedDownloadProfile();
+
     if (Util.isEmpty(profile.getName()) &&
         Util.isEmpty(profile.getAvatar()) &&
         Util.isEmpty(profile.getAbout()) &&
@@ -112,6 +114,7 @@ public class RefreshOwnProfileJob extends BaseJob {
         Log.w(TAG, "We don't have a name locally, either!");
       }
 
+      SignalStore.registrationValues().clearNeedDownloadProfileAvatar();
       return;
     }
 

--- a/app/src/main/java/org/thoughtcrime/securesms/jobs/RetrieveProfileAvatarJob.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/jobs/RetrieveProfileAvatarJob.java
@@ -83,6 +83,7 @@ public class RetrieveProfileAvatarJob extends BaseJob {
 
     if (profileAvatar != null && profileAvatar.equals(recipient.resolve().getProfileAvatar())) {
       Log.w(TAG, "Already retrieved profile avatar: " + profileAvatar);
+      SignalStore.registrationValues().clearNeedDownloadProfileAvatar();
       return;
     }
 
@@ -93,6 +94,7 @@ public class RetrieveProfileAvatarJob extends BaseJob {
         database.setProfileAvatar(recipient.getId(), profileAvatar);
       }
 
+      SignalStore.registrationValues().clearNeedDownloadProfileAvatar();
       return;
     }
 
@@ -122,6 +124,7 @@ public class RetrieveProfileAvatarJob extends BaseJob {
     }
 
     database.setProfileAvatar(recipient.getId(), profileAvatar);
+    SignalStore.registrationValues().clearNeedDownloadProfileAvatar();
   }
 
   @Override

--- a/app/src/main/java/org/thoughtcrime/securesms/jobs/StorageSyncJob.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/jobs/StorageSyncJob.java
@@ -170,7 +170,7 @@ public class StorageSyncJob extends BaseJob {
 
   @Override
   protected void onRun() throws IOException, RetryLaterException, UntrustedIdentityException {
-    if (!SignalStore.svr().hasPin() && !SignalStore.svr().hasOptedOut()) {
+    if (!SignalStore.svr().hasPin() && !SignalStore.svr().hasOptedOut() && !SignalStore.storageService().hasStorageKeyFromPrimary()) {
       Log.i(TAG, "Doesn't have a PIN. Skipping.");
       return;
     }

--- a/app/src/main/java/org/thoughtcrime/securesms/keyvalue/AccountValues.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/keyvalue/AccountValues.kt
@@ -329,8 +329,11 @@ internal class AccountValues internal constructor(store: KeyValueStore) : Signal
   val deviceName: String?
     get() = getString(KEY_DEVICE_NAME, null)
 
-  fun setDeviceName(deviceName: String) {
-    putString(KEY_DEVICE_NAME, deviceName)
+  fun setDeviceName(deviceName: String?) {
+    if (deviceName == null)
+      remove(KEY_DEVICE_NAME)
+    else
+      putString(KEY_DEVICE_NAME, deviceName)
   }
 
   var deviceId: Int by integerValue(KEY_DEVICE_ID, SignalServiceAddress.DEFAULT_DEVICE_ID)

--- a/app/src/main/java/org/thoughtcrime/securesms/keyvalue/RegistrationValues.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/keyvalue/RegistrationValues.java
@@ -9,11 +9,13 @@ import java.util.List;
 
 public final class RegistrationValues extends SignalStoreValues {
 
-  private static final String REGISTRATION_COMPLETE = "registration.complete";
-  private static final String PIN_REQUIRED          = "registration.pin_required";
-  private static final String HAS_UPLOADED_PROFILE  = "registration.has_uploaded_profile";
+  private static final String REGISTRATION_COMPLETE        = "registration.complete";
+  private static final String PIN_REQUIRED                 = "registration.pin_required";
+  private static final String HAS_UPLOADED_PROFILE         = "registration.has_uploaded_profile";
   private static final String SESSION_E164          = "registration.session_e164";
   private static final String SESSION_ID            = "registration.session_id";
+  private static final String NEED_DOWNLOAD_PROFILE        = "registration.need_download_profile";
+  private static final String NEED_DOWNLOAD_PROFILE_AVATAR = "registration.need_download_profile_avatar";
 
   RegistrationValues(@NonNull KeyValueStore store) {
     super(store);
@@ -22,6 +24,8 @@ public final class RegistrationValues extends SignalStoreValues {
   public synchronized void onFirstEverAppLaunch() {
     getStore().beginWrite()
               .putBoolean(HAS_UPLOADED_PROFILE, false)
+              .putBoolean(NEED_DOWNLOAD_PROFILE, false)
+              .putBoolean(NEED_DOWNLOAD_PROFILE_AVATAR, false)
               .putBoolean(REGISTRATION_COMPLETE, false)
               .putBoolean(PIN_REQUIRED, true)
               .commit();
@@ -80,5 +84,22 @@ public final class RegistrationValues extends SignalStoreValues {
   @Nullable
   public String getSessionE164() {
     return getString(SESSION_E164, null);
+  }
+
+  public void markNeedDownloadProfileAndAvatar() {
+    putBoolean(NEED_DOWNLOAD_PROFILE, true);
+    putBoolean(NEED_DOWNLOAD_PROFILE_AVATAR, true);
+  }
+
+  public boolean needDownloadProfileOrAvatar() {
+    return getBoolean(NEED_DOWNLOAD_PROFILE, true) || getBoolean(NEED_DOWNLOAD_PROFILE_AVATAR, true);
+  }
+
+  public void clearNeedDownloadProfile() {
+    putBoolean(NEED_DOWNLOAD_PROFILE, false);
+  }
+
+  public void clearNeedDownloadProfileAvatar() {
+    putBoolean(NEED_DOWNLOAD_PROFILE_AVATAR, false);
   }
 }

--- a/app/src/main/java/org/thoughtcrime/securesms/keyvalue/StorageServiceValues.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/keyvalue/StorageServiceValues.java
@@ -66,6 +66,10 @@ public class StorageServiceValues extends SignalStoreValues {
     }
   }
 
+  public synchronized boolean hasStorageKeyFromPrimary() {
+    return SignalStore.account().isLinkedDevice() && getStore().containsKey(SYNC_STORAGE_KEY);
+  }
+
   public synchronized void setStorageKeyFromPrimary(@NonNull StorageKey storageKey) {
     Preconditions.checkState(SignalStore.account().isLinkedDevice(), "Can only set storage key directly on linked devices");
     putBlob(SYNC_STORAGE_KEY, storageKey.serialize());

--- a/app/src/main/java/org/thoughtcrime/securesms/megaphone/PinsForAllSchedule.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/megaphone/PinsForAllSchedule.java
@@ -51,6 +51,10 @@ class PinsForAllSchedule implements MegaphoneSchedule {
       return false;
     }
 
+    if (SignalStore.account().isLinkedDevice()) {
+      return false;
+    }
+
     if (pinCreationFailedDuringRegistration()) {
       return true;
     }

--- a/app/src/main/java/org/thoughtcrime/securesms/megaphone/SignalPinReminderSchedule.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/megaphone/SignalPinReminderSchedule.java
@@ -14,6 +14,10 @@ final class SignalPinReminderSchedule implements MegaphoneSchedule {
       return false;
     }
 
+    if (SignalStore.account().isLinkedDevice()) {
+      return false;
+    }
+
     if (!SignalStore.pinValues().arePinRemindersEnabled()) {
       return false;
     }

--- a/app/src/main/java/org/thoughtcrime/securesms/messages/SyncMessageProcessor.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/messages/SyncMessageProcessor.kt
@@ -5,6 +5,9 @@ import com.google.protobuf.ByteString
 import com.mobilecoin.lib.exceptions.SerializationException
 import org.signal.core.util.Hex
 import org.signal.core.util.orNull
+import org.signal.libsignal.protocol.IdentityKeyPair
+import org.signal.libsignal.protocol.InvalidMessageException
+import org.signal.libsignal.protocol.state.SignedPreKeyRecord
 import org.signal.libsignal.protocol.util.Pair
 import org.signal.ringrtc.CallException
 import org.signal.ringrtc.CallLinkRootKey
@@ -13,11 +16,13 @@ import org.thoughtcrime.securesms.attachments.DatabaseAttachment
 import org.thoughtcrime.securesms.attachments.TombstoneAttachment
 import org.thoughtcrime.securesms.components.emoji.EmojiUtil
 import org.thoughtcrime.securesms.contactshare.Contact
+import org.thoughtcrime.securesms.crypto.PreKeyUtil
 import org.thoughtcrime.securesms.crypto.SecurityEvent
 import org.thoughtcrime.securesms.database.CallLinkTable
 import org.thoughtcrime.securesms.database.CallTable
 import org.thoughtcrime.securesms.database.GroupReceiptTable
 import org.thoughtcrime.securesms.database.GroupTable
+import org.thoughtcrime.securesms.database.IdentityTable
 import org.thoughtcrime.securesms.database.MessageTable.MarkedMessageInfo
 import org.thoughtcrime.securesms.database.NoSuchMessageException
 import org.thoughtcrime.securesms.database.PaymentMetaDataUtil
@@ -49,7 +54,9 @@ import org.thoughtcrime.securesms.jobs.MultiDeviceStickerPackSyncJob
 import org.thoughtcrime.securesms.jobs.PushProcessEarlyMessagesJob
 import org.thoughtcrime.securesms.jobs.RefreshCallLinkDetailsJob
 import org.thoughtcrime.securesms.jobs.RefreshOwnProfileJob
+import org.thoughtcrime.securesms.jobs.RotateCertificateJob
 import org.thoughtcrime.securesms.jobs.StickerPackDownloadJob
+import org.thoughtcrime.securesms.jobs.StorageSyncJob
 import org.thoughtcrime.securesms.keyvalue.SignalStore
 import org.thoughtcrime.securesms.linkpreview.LinkPreview
 import org.thoughtcrime.securesms.messages.MessageContentProcessor.Companion.log
@@ -93,11 +100,14 @@ import org.thoughtcrime.securesms.util.MediaUtil
 import org.thoughtcrime.securesms.util.MessageConstraintsUtil
 import org.thoughtcrime.securesms.util.TextSecurePreferences
 import org.thoughtcrime.securesms.util.Util
+import org.whispersystems.signalservice.api.account.PreKeyUpload
 import org.whispersystems.signalservice.api.crypto.EnvelopeMetadata
 import org.whispersystems.signalservice.api.messages.SignalServiceAttachmentPointer
 import org.whispersystems.signalservice.api.push.DistributionId
 import org.whispersystems.signalservice.api.push.ServiceId
 import org.whispersystems.signalservice.api.push.ServiceId.ACI
+import org.whispersystems.signalservice.api.push.ServiceId.PNI
+import org.whispersystems.signalservice.api.push.ServiceIdType
 import org.whispersystems.signalservice.api.push.SignalServiceAddress
 import org.whispersystems.signalservice.api.storage.StorageKey
 import org.whispersystems.signalservice.internal.push.SignalServiceProtos
@@ -112,6 +122,7 @@ import org.whispersystems.signalservice.internal.push.SignalServiceProtos.SyncMe
 import org.whispersystems.signalservice.internal.push.SignalServiceProtos.SyncMessage.Configuration
 import org.whispersystems.signalservice.internal.push.SignalServiceProtos.SyncMessage.FetchLatest
 import org.whispersystems.signalservice.internal.push.SignalServiceProtos.SyncMessage.MessageRequestResponse
+import org.whispersystems.signalservice.internal.push.SignalServiceProtos.SyncMessage.PniChangeNumber
 import org.whispersystems.signalservice.internal.push.SignalServiceProtos.SyncMessage.Read
 import org.whispersystems.signalservice.internal.push.SignalServiceProtos.SyncMessage.Request
 import org.whispersystems.signalservice.internal.push.SignalServiceProtos.SyncMessage.Sent
@@ -152,6 +163,7 @@ object SyncMessageProcessor {
       syncMessage.hasCallEvent() -> handleSynchronizeCallEvent(syncMessage.callEvent, envelope.timestamp)
       syncMessage.hasCallLinkUpdate() -> handleSynchronizeCallLink(syncMessage.callLinkUpdate, envelope.timestamp)
       syncMessage.hasCallLogEvent() -> handleSynchronizeCallLogEvent(syncMessage.callLogEvent, envelope.timestamp)
+      syncMessage.hasPniChangeNumber() -> handleSynchronizePniChangeNumber(syncMessage.pniChangeNumber, envelope.updatedPni, envelope.timestamp)
       else -> warn(envelope.timestamp, "Contains no known sync types...")
     }
   }
@@ -1135,6 +1147,8 @@ object SyncMessageProcessor {
     }
 
     SignalStore.storageService().setStorageKeyFromPrimary(StorageKey(storageKey.toByteArray()))
+
+    ApplicationDependencies.getJobManager().add(StorageSyncJob())
   }
 
   @Throws(IOException::class)
@@ -1318,5 +1332,68 @@ object SyncMessageProcessor {
         else -> warn("Unsupported event type " + event + ". Ignoring. timestamp: " + timestamp + " type: " + type + " direction: " + direction + " event: " + event + " hasPeer: " + callEvent.hasConversationId())
       }
     }
+  }
+
+  private fun handleSynchronizePniChangeNumber(pniChangeNumber: PniChangeNumber, updatedPni: String?, envelopeTimestamp: Long) {
+    if (SignalStore.account().isLinkedDevice) {
+      log(envelopeTimestamp, "Primary device changed number. Synchronizing.")
+    } else {
+      log(envelopeTimestamp, "Primary device should not receive number change updates. Ignoring.")
+      return
+    }
+
+    if (!pniChangeNumber.hasIdentityKeyPair() || !pniChangeNumber.hasRegistrationId() || !pniChangeNumber.hasSignedPreKey() || updatedPni == null) {
+      warn(envelopeTimestamp, "Incomplete synchronize PNI number message. Ignoring.")
+      return
+    }
+
+    try {
+      val signedPreKey = SignedPreKeyRecord(pniChangeNumber.signedPreKey.toByteArray())
+      val pni = PNI.parseOrThrow(updatedPni)
+
+      val pniProtocolStore = ApplicationDependencies.getProtocolStore().pni()
+      val pniMetadataStore = SignalStore.account().pniPreKeys
+
+      SignalStore.account().setPni(pni)
+      SignalStore.account().pniRegistrationId = pniChangeNumber.registrationId
+      SignalStore.account().setPniIdentityKeyAfterChangeNumber(IdentityKeyPair(pniChangeNumber.identityKeyPair.toByteArray()))
+
+      pniProtocolStore.storeSignedPreKey(signedPreKey.id, signedPreKey)
+      val oneTimePreKeys = PreKeyUtil.generateAndStoreOneTimeEcPreKeys(pniProtocolStore, pniMetadataStore)
+
+      pniMetadataStore.activeSignedPreKeyId = signedPreKey.id
+      ApplicationDependencies.getSignalServiceAccountManager().setPreKeys(
+        PreKeyUpload(
+          serviceIdType = ServiceIdType.PNI,
+          identityKey = pniProtocolStore.identityKeyPair.publicKey,
+          signedPreKey = signedPreKey,
+          oneTimeEcPreKeys = oneTimePreKeys,
+          lastResortKyberPreKey = null,
+          oneTimeKyberPreKeys = null
+        )
+      )
+      pniMetadataStore.isSignedPreKeyRegistered = true
+
+      pniProtocolStore.identities().saveIdentityWithoutSideEffects(
+        Recipient.self().id,
+        pni,
+        pniProtocolStore.identityKeyPair.publicKey,
+        IdentityTable.VerifiedStatus.VERIFIED,
+        true,
+        System.currentTimeMillis(),
+        true
+      )
+
+      SignalStore.misc().setPniInitializedDevices(true)
+      ApplicationDependencies.getGroupsV2Authorization().clear()
+    } catch (e: InvalidMessageException) {
+      warn(envelopeTimestamp, "Invalid signed prekey received while synchronize number change", e)
+      return
+    }
+
+    ApplicationDependencies.closeConnections()
+    ApplicationDependencies.getIncomingMessageObserver()
+
+    ApplicationDependencies.getJobManager().add(RotateCertificateJob())
   }
 }

--- a/app/src/main/java/org/thoughtcrime/securesms/push/AccountManagerFactory.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/push/AccountManagerFactory.java
@@ -13,8 +13,13 @@ import org.thoughtcrime.securesms.BuildConfig;
 import org.thoughtcrime.securesms.dependencies.ApplicationDependencies;
 import org.thoughtcrime.securesms.util.FeatureFlags;
 import org.whispersystems.signalservice.api.SignalServiceAccountManager;
+import org.whispersystems.signalservice.api.groupsv2.ClientZkOperations;
+import org.whispersystems.signalservice.api.groupsv2.GroupsV2Operations;
 import org.whispersystems.signalservice.api.push.ServiceId.ACI;
 import org.whispersystems.signalservice.api.push.ServiceId.PNI;
+import org.whispersystems.signalservice.api.push.SignalServiceAddress;
+import org.whispersystems.signalservice.internal.util.DynamicCredentialsProvider;
+import org.whispersystems.signalservice.internal.configuration.SignalServiceConfiguration;
 
 public class AccountManagerFactory {
 
@@ -93,6 +98,22 @@ public class AccountManagerFactory {
                                            BuildConfig.SIGNAL_AGENT,
                                            FeatureFlags.okHttpAutomaticRetry(),
                                            FeatureFlags.groupLimits().getHardLimit());
+  }
+
+  /**
+   * Should only be used during registration when linking to an existing device.
+   */
+  public static @NonNull SignalServiceAccountManager createForDeviceLink(@NonNull Context context,
+                                                                         @NonNull String password)
+  {
+    // Limitation - We cannot detect the need to use a censored configuration for the link process, because the number (and hence country code) is unknown.
+    // Perhaps offer a UI to select just the country, and obtain censorship configuration that way?
+    SignalServiceConfiguration configuration = ApplicationDependencies.getSignalServiceNetworkAccess().getConfiguration(null);
+    return new SignalServiceAccountManager(configuration,
+                                           new DynamicCredentialsProvider(null, null, null, password, SignalServiceAddress.DEFAULT_DEVICE_ID),
+                                           BuildConfig.SIGNAL_AGENT,
+                                           new GroupsV2Operations(ClientZkOperations.create(configuration), FeatureFlags.groupLimits().getHardLimit()),
+                                           FeatureFlags.okHttpAutomaticRetry());
   }
 
 }

--- a/app/src/main/java/org/thoughtcrime/securesms/registration/LinkDeviceRepository.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/registration/LinkDeviceRepository.kt
@@ -1,0 +1,111 @@
+package org.thoughtcrime.securesms.registration
+
+import android.app.Application
+import io.reactivex.rxjava3.core.Single
+import io.reactivex.rxjava3.schedulers.Schedulers
+import org.signal.core.util.logging.Log
+import org.signal.libsignal.protocol.IdentityKeyPair
+import org.thoughtcrime.securesms.crypto.IdentityKeyUtil
+import org.thoughtcrime.securesms.push.AccountManagerFactory
+import org.whispersystems.signalservice.api.SignalServiceAccountManager
+import org.whispersystems.signalservice.api.util.DeviceNameUtil
+import org.whispersystems.signalservice.internal.ServiceResponse
+import org.whispersystems.signalservice.internal.ServiceResponseProcessor
+import org.whispersystems.signalservice.internal.push.ConfirmCodeMessage
+import org.whispersystems.util.Base64
+import java.io.IOException
+import java.net.URLEncoder
+
+/**
+ * Link a new device to an existing primary device.
+ */
+class LinkDeviceRepository(private val context: Application) {
+
+  fun requestDeviceLinkCode(
+    registrationData: RegistrationData,
+    deviceName: String?
+  ): Single<LinkDeviceProgressProcessor> {
+    Log.d(TAG, "Device link requested")
+
+    val tempIdentityKey: IdentityKeyPair = IdentityKeyUtil.generateIdentityKeyPair()
+    val accountManager: SignalServiceAccountManager = AccountManagerFactory.createForDeviceLink(
+      context,
+      registrationData.password
+    )
+
+    return Single.fromCallable<ServiceResponse<LinkDeviceProgress>> {
+      try {
+        ServiceResponse.forResult(
+          LinkDeviceProgressImpl(
+            "sgnl://linkdevice?uuid=" +
+              URLEncoder.encode(accountManager.newDeviceUuid, "utf-8") +
+              "&pub_key=" +
+              URLEncoder.encode(Base64.encodeBytesWithoutPadding(tempIdentityKey.publicKey.publicKey.serialize()), "utf-8"),
+            tempIdentityKey,
+            accountManager,
+            registrationData,
+            deviceName
+          ),
+          200, null
+        )
+      } catch (e: IOException) {
+        ServiceResponse.forExecutionError(e)
+      }
+    }.subscribeOn(Schedulers.io()).map(::LinkDeviceProgressProcessor)
+  }
+
+  fun attemptDeviceLink(
+    progress: LinkDeviceProgress
+  ): Single<LinkDeviceResponseProcessor> {
+    val progressImpl: LinkDeviceProgressImpl = progress as LinkDeviceProgressImpl
+    val tempIdentityKey: IdentityKeyPair = progressImpl.tempIdentityKey
+    val accountManager: SignalServiceAccountManager = progressImpl.accountManager
+    val registrationData: RegistrationData = progressImpl.registrationData
+    val deviceName: String? = progressImpl.deviceName
+
+    return Single.fromCallable<ServiceResponse<LinkDeviceResponse>> {
+      try {
+        val ret = accountManager.getNewDeviceRegistration(tempIdentityKey)
+        val encryptedDeviceName = deviceName?.let { DeviceNameUtil.encryptDeviceName(it, ret.aciIdentity.privateKey) }
+        val deviceId = accountManager.finishNewDeviceRegistration(
+          ret.provisioningCode,
+          ConfirmCodeMessage(
+            false,
+            true,
+            registrationData.registrationId,
+            registrationData.pniRegistrationId,
+            encryptedDeviceName,
+            null
+          )
+        )
+        ServiceResponse.forResult(LinkDeviceResponse(ret, deviceId), 200, null)
+      } catch (e: IOException) {
+        ServiceResponse.forExecutionError(e)
+      }
+    }.subscribeOn(Schedulers.io()).map(::LinkDeviceResponseProcessor)
+  }
+
+  companion object {
+    private val TAG = Log.tag(LinkDeviceRepository::class.java)
+  }
+
+  class LinkDeviceProgressProcessor(response: ServiceResponse<LinkDeviceProgress>) : ServiceResponseProcessor<LinkDeviceProgress>(response) {
+    fun asNewDeviceRegistrationReturnProcessor(): NewDeviceRegistrationReturnProcessor {
+      return NewDeviceRegistrationReturnProcessor(ServiceResponse.coerceError(response))
+    }
+  }
+  class LinkDeviceResponseProcessor(response: ServiceResponse<LinkDeviceResponse>) : ServiceResponseProcessor<LinkDeviceResponse>(response) {
+    fun asNewDeviceRegistrationReturnProcessor(): NewDeviceRegistrationReturnProcessor {
+      return NewDeviceRegistrationReturnProcessor(ServiceResponse.coerceError(response))
+    }
+  }
+  class NewDeviceRegistrationReturnProcessor(response: ServiceResponse<SignalServiceAccountManager.NewDeviceRegistrationReturn>) : ServiceResponseProcessor<SignalServiceAccountManager.NewDeviceRegistrationReturn>(response)
+
+  data class LinkDeviceResponse(val newDeviceRegistrationResponse: SignalServiceAccountManager.NewDeviceRegistrationReturn, val deviceId: Int)
+
+  interface LinkDeviceProgress {
+    val deviceLinkCode: String
+  }
+
+  private data class LinkDeviceProgressImpl(override val deviceLinkCode: String, val tempIdentityKey: IdentityKeyPair, val accountManager: SignalServiceAccountManager, val registrationData: RegistrationData, val deviceName: String?) : LinkDeviceProgress
+}

--- a/app/src/main/java/org/thoughtcrime/securesms/registration/RegistrationRepository.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/registration/RegistrationRepository.java
@@ -24,8 +24,10 @@ import org.thoughtcrime.securesms.database.RecipientTable;
 import org.thoughtcrime.securesms.database.SignalDatabase;
 import org.thoughtcrime.securesms.dependencies.ApplicationDependencies;
 import org.thoughtcrime.securesms.jobmanager.JobManager;
+import org.thoughtcrime.securesms.jobs.AllDataSyncRequestJob;
 import org.thoughtcrime.securesms.jobs.DirectoryRefreshJob;
 import org.thoughtcrime.securesms.jobs.PreKeysSyncJob;
+import org.thoughtcrime.securesms.jobs.RefreshOwnProfileJob;
 import org.thoughtcrime.securesms.jobs.RotateCertificateJob;
 import org.thoughtcrime.securesms.keyvalue.SignalStore;
 import org.thoughtcrime.securesms.notifications.NotificationIds;
@@ -37,10 +39,14 @@ import org.thoughtcrime.securesms.service.DirectoryRefreshListener;
 import org.thoughtcrime.securesms.service.RotateSignedPreKeyListener;
 import org.thoughtcrime.securesms.util.TextSecurePreferences;
 import org.whispersystems.signalservice.api.SignalServiceAccountManager;
+import org.whispersystems.signalservice.api.SignalServiceAccountManager.NewDeviceRegistrationReturn;
 import org.whispersystems.signalservice.api.account.PreKeyCollection;
+import org.whispersystems.signalservice.api.account.PreKeyUpload;
+import org.whispersystems.signalservice.api.kbs.MasterKey;
 import org.whispersystems.signalservice.api.push.ServiceId.ACI;
 import org.whispersystems.signalservice.api.push.ServiceId.PNI;
 import org.whispersystems.signalservice.api.push.ServiceId;
+import org.whispersystems.signalservice.api.push.ServiceIdType;
 import org.whispersystems.signalservice.api.push.SignalServiceAddress;
 import org.whispersystems.signalservice.api.util.Preconditions;
 import org.whispersystems.signalservice.internal.ServiceResponse;
@@ -119,21 +125,93 @@ public final class RegistrationRepository {
     }).subscribeOn(Schedulers.io());
   }
 
+  public Single<ServiceResponse<NewDeviceRegistrationReturn>> registerAccountFromPrimaryDevice(@NonNull RegistrationData registrationData,
+                                                                                                                           @NonNull NewDeviceRegistrationReturn response,
+                                                                                                                           int deviceId,
+                                                                                                                           String deviceName)
+  {
+    return Single.<ServiceResponse<NewDeviceRegistrationReturn>>fromCallable(() -> {
+      try {
+        // We have to set the deviceId before setting the identity keys, or they will throw for not being a linked device
+        // But we also have to set the identity keys before calling registerAccountInternal, otherwise it will generate new ones when creating the prekeys
+        SignalStore.account().setDeviceId(deviceId);
+        SignalStore.account().setAciIdentityKeysFromPrimaryDevice(response.getAciIdentity());
+        SignalStore.account().setPniIdentityKeyAfterChangeNumber(response.getPniIdentity());
+        SignalStore.registrationValues().markNeedDownloadProfileAndAvatar();
+        registerAccountInternal(new RegistrationData(registrationData.getCode(),
+                                                     response.getNumber(),
+                                                     registrationData.getPassword(),
+                                                     registrationData.getRegistrationId(),
+                                                     response.getProfileKey() == null ? ProfileKeyUtil.createNew() : response.getProfileKey(),
+                                                     registrationData.getFcmToken(),
+                                                     registrationData.getPniRegistrationId(),
+                                                     registrationData.getRecoveryPassword()),
+                                response.getAci(), response.getPni(),
+                                generateSignedAndLastResortPreKeys(response.getAciIdentity(), SignalStore.account().aciPreKeys()),
+                                generateSignedAndLastResortPreKeys(response.getPniIdentity(), SignalStore.account().pniPreKeys()),
+                                false, deviceId, deviceName, null, null, false);
+
+        JobManager jobManager = ApplicationDependencies.getJobManager();
+        jobManager.add(new RotateCertificateJob());
+        jobManager.add(new AllDataSyncRequestJob());
+        jobManager.add(new RefreshOwnProfileJob());
+
+        RotateSignedPreKeyListener.schedule(context);
+
+        return ServiceResponse.forResult(response, 200, null);
+      } catch (IOException e) {
+        return ServiceResponse.forUnknownError(e);
+      }
+    }).subscribeOn(Schedulers.io());
+  }
+
   @WorkerThread
   private void registerAccountInternal(@NonNull RegistrationData registrationData,
                                        @NonNull VerifyResponse response,
                                        boolean setRegistrationLockEnabled)
       throws IOException
   {
-    Preconditions.checkNotNull(response.getAciPreKeyCollection(), "Missing ACI prekey collection!");
-    Preconditions.checkNotNull(response.getPniPreKeyCollection(), "Missing PNI prekey collection!");
+    SignalStore.registrationValues().clearNeedDownloadProfile();
+    SignalStore.registrationValues().clearNeedDownloadProfileAvatar();
+    registerAccountInternal(
+        registrationData,
+        ACI.parseOrThrow(response.getVerifyAccountResponse().getUuid()),
+        PNI.parseOrThrow(response.getVerifyAccountResponse().getPni()),
+        response.getAciPreKeyCollection(),
+        response.getPniPreKeyCollection(),
+        response.getVerifyAccountResponse().isStorageCapable(),
+        SignalServiceAddress.DEFAULT_DEVICE_ID,
+        null,
+        response.getMasterKey(),
+        response.getPin(),
+        setRegistrationLockEnabled
+    );
+  }
 
-    ACI     aci    = ACI.parseOrThrow(response.getVerifyAccountResponse().getUuid());
-    PNI     pni    = PNI.parseOrThrow(response.getVerifyAccountResponse().getPni());
-    boolean hasPin = response.getVerifyAccountResponse().isStorageCapable();
+  @WorkerThread
+  private void registerAccountInternal(@NonNull RegistrationData registrationData,
+                                       @NonNull ACI aci,
+                                       @NonNull PNI pni,
+                                       @Nullable PreKeyCollection aciPreKeyCollection,
+                                       @Nullable PreKeyCollection pniPreKeyCollection,
+                                       boolean hasPin,
+                                       int deviceId,
+                                       @Nullable String deviceName,
+                                       @Nullable MasterKey masterKey,
+                                       @Nullable String userPin,
+                                       boolean setRegistrationLockEnabled)
+      throws IOException
+  {
+    Preconditions.checkNotNull(aciPreKeyCollection, "Missing ACI prekey collection!");
+    Preconditions.checkNotNull(pniPreKeyCollection, "Missing PNI prekey collection!");
 
     SignalStore.account().setAci(aci);
     SignalStore.account().setPni(pni);
+    SignalStore.account().setDeviceId(deviceId);
+    SignalStore.account().setDeviceName(deviceName);
+    if (deviceId != SignalServiceAddress.DEFAULT_DEVICE_ID) {
+      TextSecurePreferences.setMultiDevice(context, true);
+    }
 
     ApplicationDependencies.getProtocolStore().aci().sessions().archiveAllSessions();
     ApplicationDependencies.getProtocolStore().pni().sessions().archiveAllSessions();
@@ -145,8 +223,8 @@ public final class RegistrationRepository {
     SignalServiceAccountDataStoreImpl pniProtocolStore = ApplicationDependencies.getProtocolStore().pni();
     PreKeyMetadataStore               pniMetadataStore = SignalStore.account().pniPreKeys();
 
-    storeSignedAndLastResortPreKeys(aciProtocolStore, aciMetadataStore, response.getAciPreKeyCollection());
-    storeSignedAndLastResortPreKeys(pniProtocolStore, pniMetadataStore, response.getPniPreKeyCollection());
+    storeSignedAndLastResortPreKeys(aciProtocolStore, aciMetadataStore, aciPreKeyCollection);
+    storeSignedAndLastResortPreKeys(pniProtocolStore, pniMetadataStore, pniPreKeyCollection);
 
     RecipientTable recipientTable = SignalDatabase.recipients();
     RecipientId    selfId         = Recipient.trustedPush(aci, pni, registrationData.getE164()).getId();
@@ -167,12 +245,29 @@ public final class RegistrationRepository {
     saveOwnIdentityKey(selfId, pni, pniProtocolStore, now);
 
     SignalStore.account().setServicePassword(registrationData.getPassword());
+
+    if (deviceId != SignalServiceAddress.DEFAULT_DEVICE_ID) {
+      SignalServiceAccountManager accountManager = ApplicationDependencies.getSignalServiceAccountManager();
+      accountManager.setPreKeys(
+          new PreKeyUpload(ServiceIdType.ACI,
+                           aciPreKeyCollection.getIdentityKey(),
+                           aciPreKeyCollection.getSignedPreKey(),
+                           PreKeyUtil.generateAndStoreOneTimeEcPreKeys(aciProtocolStore, aciMetadataStore),
+                           null, null));
+      accountManager.setPreKeys(
+          new PreKeyUpload(ServiceIdType.PNI,
+                           pniPreKeyCollection.getIdentityKey(),
+                           pniPreKeyCollection.getSignedPreKey(),
+                           PreKeyUtil.generateAndStoreOneTimeEcPreKeys(pniProtocolStore, pniMetadataStore),
+                           null, null));
+    }
+
     SignalStore.account().setRegistered(true);
     TextSecurePreferences.setPromptedPushRegistration(context, true);
     TextSecurePreferences.setUnauthorizedReceived(context, false);
     NotificationManagerCompat.from(context).cancel(NotificationIds.UNREGISTERED_NOTIFICATION_ID);
 
-    SvrRepository.onRegistrationComplete(response.getMasterKey(), response.getPin(), hasPin, setRegistrationLockEnabled);
+    SvrRepository.onRegistrationComplete(masterKey, userPin, hasPin, setRegistrationLockEnabled);
 
     ApplicationDependencies.closeConnections();
     ApplicationDependencies.getIncomingMessageObserver();

--- a/app/src/main/java/org/thoughtcrime/securesms/registration/RegistrationUtil.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/registration/RegistrationUtil.java
@@ -21,8 +21,8 @@ public final class RegistrationUtil {
   public static void maybeMarkRegistrationComplete() {
     if (!SignalStore.registrationValues().isRegistrationComplete() &&
         SignalStore.account().isRegistered()                       &&
-        !Recipient.self().getProfileName().isEmpty()               &&
-        (SignalStore.svr().hasPin() || SignalStore.svr().hasOptedOut()))
+        ((!Recipient.self().getProfileName().isEmpty()               &&
+        (SignalStore.svr().hasPin() || SignalStore.svr().hasOptedOut())) || SignalStore.account().isLinkedDevice()))
     {
       Log.i(TAG, "Marking registration completed.", new Throwable());
       SignalStore.registrationValues().setRegistrationComplete();

--- a/app/src/main/java/org/thoughtcrime/securesms/registration/fragments/EnterPhoneNumberFragment.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/registration/fragments/EnterPhoneNumberFragment.java
@@ -75,6 +75,7 @@ public final class EnterPhoneNumberFragment extends LoggingFragment implements R
   private TextInputLayout                countryCode;
   private TextInputLayout                number;
   private CircularProgressMaterialButton register;
+  private View                           linkDevice;
   private View                           cancel;
   private ScrollView                     scrollView;
   private RegistrationViewModel          viewModel;
@@ -103,12 +104,14 @@ public final class EnterPhoneNumberFragment extends LoggingFragment implements R
     cancel      = view.findViewById(R.id.cancel_button);
     scrollView  = view.findViewById(R.id.scroll_view);
     register    = view.findViewById(R.id.registerButton);
+    linkDevice     = view.findViewById(R.id.link_button);
 
     RegistrationNumberInputController controller = new RegistrationNumberInputController(requireContext(),
                                                                                          this,
                                                                                          Objects.requireNonNull(number.getEditText()),
                                                                                          countryCode);
     register.setOnClickListener(v -> handleRegister(requireContext()));
+    linkDevice.setOnClickListener(v -> SafeNavigation.safeNavigate(Navigation.findNavController(v), EnterPhoneNumberFragmentDirections.actionLinkDevice()));
 
     disposables.bindTo(getViewLifecycleOwner().getLifecycle());
     viewModel = new ViewModelProvider(requireActivity()).get(RegistrationViewModel.class);

--- a/app/src/main/java/org/thoughtcrime/securesms/registration/fragments/LinkDeviceFragment.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/registration/fragments/LinkDeviceFragment.java
@@ -1,0 +1,133 @@
+package org.thoughtcrime.securesms.registration.fragments;
+
+import android.content.Context;
+import android.os.Bundle;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.TextView;
+import android.widget.Toast;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.lifecycle.ViewModelProvider;
+import androidx.navigation.Navigation;
+
+import org.signal.core.util.concurrent.LifecycleDisposable;
+import org.signal.core.util.logging.Log;
+import org.thoughtcrime.securesms.LoggingFragment;
+import org.thoughtcrime.securesms.R;
+import org.thoughtcrime.securesms.components.qr.QrView;
+import org.thoughtcrime.securesms.dependencies.ApplicationDependencies;
+import org.thoughtcrime.securesms.keyvalue.SignalStore;
+import org.thoughtcrime.securesms.registration.viewmodel.RegistrationViewModel;
+import org.thoughtcrime.securesms.util.TextSecurePreferences;
+import org.thoughtcrime.securesms.util.Util;
+import org.thoughtcrime.securesms.util.navigation.SafeNavigation;
+
+import java.io.IOException;
+import java.util.concurrent.TimeoutException;
+
+import io.reactivex.rxjava3.core.Single;
+import io.reactivex.rxjava3.android.schedulers.AndroidSchedulers;
+
+public final class LinkDeviceFragment extends LoggingFragment {
+
+  private static final String TAG = Log.tag(LinkDeviceFragment.class);
+
+  private int                   state;
+  private View                  loadingSpinner;
+  private QrView                qrImageView;
+  private TextView              textCode;
+  private View                  labelError;
+  private View                  labelTimeout;
+  private View                  retry;
+  private RegistrationViewModel viewModel;
+
+  private final LifecycleDisposable disposables = new LifecycleDisposable();
+
+  @Override
+  public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
+    return inflater.inflate(R.layout.fragment_registration_link_device, container, false);
+  }
+
+  @Override
+  public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
+    super.onViewCreated(view, savedInstanceState);
+
+    loadingSpinner = view.findViewById(R.id.linking_loading_spinner);
+    qrImageView    = view.findViewById(R.id.linking_qr_image);
+    textCode       = view.findViewById(R.id.linking_text_code);
+    labelError     = view.findViewById(R.id.linking_error);
+    labelTimeout   = view.findViewById(R.id.linking_timeout);
+    retry          = view.findViewById(R.id.link_retry_button);
+
+    disposables.bindTo(getViewLifecycleOwner().getLifecycle());
+    viewModel = new ViewModelProvider(requireActivity()).get(RegistrationViewModel.class);
+
+    TextSecurePreferences.setHasSeenNetworkConfig(requireContext(), true);
+    ApplicationDependencies.getNetworkManager().setNetworkEnabled(true);
+
+    state = 0;
+    attemptDeviceLink();
+
+    retry.setOnClickListener(v -> attemptDeviceLink());
+
+    textCode.setOnClickListener(v -> {
+      Context context = requireContext();
+      Util.copyToClipboard(context, textCode.getText());
+      Toast.makeText(context, R.string.RegistrationActivity_copied_to_clipboard, Toast.LENGTH_SHORT).show();
+    });
+  }
+
+  private void attemptDeviceLink() {
+    if (state != 0) return;
+    loadingSpinner.setVisibility(View.VISIBLE);
+    labelError.setVisibility(View.GONE);
+    labelTimeout.setVisibility(View.GONE);
+    retry.setVisibility(View.GONE);
+    state = 1;
+    // This is hacky, but LifecycleDisposable doesn't expose a method to remove a single disposable,
+    // and we will leak for each repeated attempt if we don't clear it before a retry
+    disposables.clear();
+    disposables.add(
+      viewModel.requestDeviceLinkCode()
+               .doOnSubscribe(unused -> SignalStore.account().setRegistered(false))
+               .observeOn(AndroidSchedulers.mainThread())
+               .flatMap(processor -> {
+                 if (processor.hasResult()) {
+                   state = 2;
+                   String deviceLinkCode = processor.getResult().getDeviceLinkCode();
+                   Log.d(TAG, "Displaying device link code: "+deviceLinkCode);
+                   qrImageView.setQrText(deviceLinkCode);
+                   textCode.setText(deviceLinkCode);
+                   loadingSpinner.setVisibility(View.GONE);
+                   qrImageView.setVisibility(View.VISIBLE);
+                   textCode.setVisibility(View.VISIBLE);
+                   return viewModel.attemptDeviceLink(processor.getResult());
+                 }
+                 return Single.just(processor.asNewDeviceRegistrationReturnProcessor());
+               })
+               .observeOn(AndroidSchedulers.mainThread())
+               .subscribe(processor -> {
+                 try {
+                   processor.getResultOrThrow();
+                   state = -1;
+                   SafeNavigation.safeNavigate(Navigation.findNavController(requireView()), LinkDeviceFragmentDirections.actionLinkDeviceComplete());
+                 } catch (Throwable t) {
+                   Log.w(TAG, "Failed to link device. Allowing user to retry", t);
+                   loadingSpinner.setVisibility(View.GONE);
+                   qrImageView.setVisibility(View.GONE);
+                   textCode.setVisibility(View.GONE);
+                   if (state == 2) {
+                     labelTimeout.setVisibility(View.VISIBLE);
+                   } else {
+                     labelError.setVisibility(View.VISIBLE);
+                   }
+                   retry.setVisibility(View.VISIBLE);
+                   state = 0;
+                 }
+               })
+    );
+  }
+}

--- a/app/src/main/java/org/thoughtcrime/securesms/registration/fragments/LinkDeviceNameFragment.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/registration/fragments/LinkDeviceNameFragment.java
@@ -1,0 +1,66 @@
+package org.thoughtcrime.securesms.registration.fragments;
+
+import android.os.Bundle;
+import android.text.Editable;
+import android.text.TextWatcher;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.lifecycle.ViewModelProvider;
+import androidx.navigation.Navigation;
+
+import org.signal.core.util.concurrent.LifecycleDisposable;
+import org.signal.core.util.logging.Log;
+import org.thoughtcrime.securesms.LoggingFragment;
+import org.thoughtcrime.securesms.R;
+import org.thoughtcrime.securesms.components.LabeledEditText;
+import org.thoughtcrime.securesms.registration.viewmodel.RegistrationViewModel;
+import org.thoughtcrime.securesms.util.navigation.SafeNavigation;
+
+public final class LinkDeviceNameFragment extends LoggingFragment {
+
+  private static final String TAG = Log.tag(LinkDeviceNameFragment.class);
+
+  private LabeledEditText       deviceName;
+  private View                  linkDevice;
+  private RegistrationViewModel viewModel;
+
+  private final LifecycleDisposable disposables = new LifecycleDisposable();
+
+  @Override
+  public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
+    return inflater.inflate(R.layout.fragment_registration_link_device_name, container, false);
+  }
+
+  @Override
+  public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
+    super.onViewCreated(view, savedInstanceState);
+
+    deviceName = view.findViewById(R.id.device_name);
+    linkDevice = view.findViewById(R.id.link_button);
+
+    disposables.bindTo(getViewLifecycleOwner().getLifecycle());
+    viewModel = new ViewModelProvider(requireActivity()).get(RegistrationViewModel.class);
+
+    deviceName.getInput().addTextChangedListener(new TextWatcher() {
+      @Override
+      public void afterTextChanged(Editable s) {
+        if (s == null) return;
+
+        viewModel.setDeviceName(s.toString());
+      }
+
+      @Override
+      public void beforeTextChanged(CharSequence s, int start, int count, int after) {
+      }
+
+      @Override
+      public void onTextChanged(CharSequence s, int start, int before, int count) {
+      }
+    });
+    linkDevice.setOnClickListener(v -> SafeNavigation.safeNavigate(Navigation.findNavController(v), LinkDeviceNameFragmentDirections.actionLinkDevice()));
+  }
+}

--- a/app/src/main/java/org/thoughtcrime/securesms/registration/fragments/RegistrationCompleteFragment.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/registration/fragments/RegistrationCompleteFragment.kt
@@ -50,8 +50,14 @@ class RegistrationCompleteFragment : LoggingFragment() {
     } else {
       val isProfileNameEmpty = Recipient.self().profileName.isEmpty
       val isAvatarEmpty = !AvatarHelper.hasAvatar(activity, Recipient.self().id)
-      val needsProfile = isProfileNameEmpty || isAvatarEmpty
-      val needsPin = !SignalStore.svr().hasPin() && !viewModel.isReregister
+      var needsProfile = isProfileNameEmpty || isAvatarEmpty
+      var needsPin = !SignalStore.svr().hasPin() && !viewModel.isReregister
+
+      if (SignalStore.account().isLinkedDevice) {
+        // This is a link, and not a new registration. Give the device a chance to sync the info from main before force-changing it.
+        needsProfile = false
+        needsPin = false
+      }
 
       Log.i(TAG, "Pin restore flow not required. Profile name: $isProfileNameEmpty | Profile avatar: $isAvatarEmpty | Needs PIN: $needsPin")
 

--- a/app/src/main/java/org/thoughtcrime/securesms/registration/viewmodel/RegistrationViewModel.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/registration/viewmodel/RegistrationViewModel.java
@@ -18,6 +18,7 @@ import org.thoughtcrime.securesms.jobs.StorageSyncJob;
 import org.thoughtcrime.securesms.keyvalue.SignalStore;
 import org.thoughtcrime.securesms.pin.SvrWrongPinException;
 import org.thoughtcrime.securesms.pin.SvrRepository;
+import org.thoughtcrime.securesms.registration.LinkDeviceRepository;
 import org.thoughtcrime.securesms.registration.RegistrationData;
 import org.thoughtcrime.securesms.registration.RegistrationRepository;
 import org.thoughtcrime.securesms.registration.RegistrationSessionProcessor;
@@ -30,6 +31,7 @@ import org.thoughtcrime.securesms.util.FeatureFlags;
 import org.thoughtcrime.securesms.util.Util;
 import org.whispersystems.signalservice.api.SvrNoDataException;
 import org.whispersystems.signalservice.api.kbs.MasterKey;
+import org.whispersystems.signalservice.api.SignalServiceAccountManager;
 import org.whispersystems.signalservice.api.kbs.PinHashUtil;
 import org.whispersystems.signalservice.api.push.exceptions.IncorrectCodeException;
 import org.whispersystems.signalservice.api.push.exceptions.IncorrectRegistrationRecoveryPasswordException;
@@ -56,8 +58,10 @@ public final class RegistrationViewModel extends BaseRegistrationViewModel {
   private static final String STATE_RESTORE_FLOW_SHOWN = "RESTORE_FLOW_SHOWN";
   private static final String STATE_IS_REREGISTER      = "IS_REREGISTER";
   private static final String STATE_BACKUP_COMPLETED   = "BACKUP_COMPLETED";
+  private static final String STATE_DEVICE_NAME        = "DEVICE_NAME_ENTERED";
 
   private final RegistrationRepository registrationRepository;
+  private final LinkDeviceRepository linkDeviceRepository;
 
   private boolean userSkippedReRegisterFlow = false;
   private boolean autoShowSmsConfirmDialog = false;
@@ -65,14 +69,17 @@ public final class RegistrationViewModel extends BaseRegistrationViewModel {
   public RegistrationViewModel(@NonNull SavedStateHandle savedStateHandle,
                                boolean isReregister,
                                @NonNull VerifyAccountRepository verifyAccountRepository,
-                               @NonNull RegistrationRepository registrationRepository)
+                               @NonNull RegistrationRepository registrationRepository,
+                               @NonNull LinkDeviceRepository linkDeviceRepository)
   {
     super(savedStateHandle, verifyAccountRepository, Util.getSecret(18));
 
     this.registrationRepository = registrationRepository;
+    this.linkDeviceRepository = linkDeviceRepository;
 
     setInitialDefaultValue(STATE_RESTORE_FLOW_SHOWN, false);
     setInitialDefaultValue(STATE_BACKUP_COMPLETED, false);
+    setInitialDefaultValue(STATE_DEVICE_NAME, "");
 
     this.savedState.set(STATE_IS_REREGISTER, isReregister);
   }
@@ -136,12 +143,36 @@ public final class RegistrationViewModel extends BaseRegistrationViewModel {
     }
   }
 
+  public @NonNull String getDeviceName() {
+    //noinspection ConstantConditions
+    return savedState.get(STATE_DEVICE_NAME);
+  }
+
+  public void setDeviceName(@NonNull String deviceName) {
+    savedState.set(STATE_DEVICE_NAME, deviceName);
+  }
+
   public boolean shouldAutoShowSmsConfirmDialog() {
     return autoShowSmsConfirmDialog;
   }
 
   public void setAutoShowSmsConfirmDialog(boolean autoShowSmsConfirmDialog) {
     this.autoShowSmsConfirmDialog = autoShowSmsConfirmDialog;
+  }
+
+  public Single<LinkDeviceRepository.LinkDeviceProgressProcessor> requestDeviceLinkCode() {
+    return linkDeviceRepository.requestDeviceLinkCode(getRegistrationData(), getDeviceName());
+  }
+
+  public Single<LinkDeviceRepository.NewDeviceRegistrationReturnProcessor> attemptDeviceLink(LinkDeviceRepository.LinkDeviceProgress progress) {
+    return linkDeviceRepository.attemptDeviceLink(progress)
+                               .flatMap(processor -> {
+                                 if (processor.hasResult()) {
+                                   return registrationRepository.registerAccountFromPrimaryDevice(getRegistrationData(), processor.getResult().getNewDeviceRegistrationResponse(), processor.getResult().getDeviceId(), getDeviceName())
+                                                                .map(LinkDeviceRepository.NewDeviceRegistrationReturnProcessor::new);
+                                 }
+                                 return Single.just(processor.asNewDeviceRegistrationReturnProcessor());
+                               });
   }
 
   @Override
@@ -446,7 +477,8 @@ public final class RegistrationViewModel extends BaseRegistrationViewModel {
       return modelClass.cast(new RegistrationViewModel(handle,
                                                        isReregister,
                                                        new VerifyAccountRepository(ApplicationDependencies.getApplication()),
-                                                       new RegistrationRepository(ApplicationDependencies.getApplication())));
+                                                       new RegistrationRepository(ApplicationDependencies.getApplication()),
+                                                       new LinkDeviceRepository(ApplicationDependencies.getApplication())));
     }
   }
 }

--- a/app/src/main/java/org/thoughtcrime/securesms/util/ProfileUtil.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/util/ProfileUtil.java
@@ -305,6 +305,11 @@ public final class ProfileUtil {
                                     @NonNull List<Badge> badges)
       throws IOException
   {
+    if (SignalStore.registrationValues().needDownloadProfileOrAvatar()) {
+      // Prevent uploading an empty profile after linking a device, but before having a chance to pull the existing profile from the primary device
+      Log.w(TAG, "Profile download pending. Skipping profile upload.");
+      return;
+    }
     List<String> badgeIds = badges.stream()
                                   .filter(Badge::getVisible)
                                   .map(Badge::getId)

--- a/app/src/main/res/layout/device_list_fragment.xml
+++ b/app/src/main/res/layout/device_list_fragment.xml
@@ -22,20 +22,6 @@
             android:indeterminate="true" />
     </LinearLayout>
 
-    <TextView
-        android:id="@+id/empty"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:layout_gravity="center|center_vertical"
-        android:layout_weight="1"
-        android:gravity="center|center_vertical"
-        android:paddingStart="16dip"
-        android:paddingEnd="16dip"
-        android:text="@string/device_list_fragment__no_devices_linked"
-        android:textSize="20sp"
-        android:visibility="gone"
-        tools:visibility="visible" />
-
     <ListView
         android:id="@id/android:list"
         android:layout_width="match_parent"

--- a/app/src/main/res/layout/device_list_item_view.xml
+++ b/app/src/main/res/layout/device_list_item_view.xml
@@ -17,6 +17,22 @@
               android:layout_width="wrap_content"
               android:layout_height="wrap_content" />
 
+    <TextView android:id="@+id/primary"
+              android:layout_width="match_parent"
+              android:layout_height="wrap_content"
+              android:textAppearance="?android:attr/textAppearanceSmall"
+              android:textColor="@color/signal_text_secondary"
+              android:text="@string/DeviceListItem_primary"
+              android:fontFamily="sans-serif-light"  />
+
+    <TextView android:id="@+id/this_device"
+              android:layout_width="match_parent"
+              android:layout_height="wrap_content"
+              android:textAppearance="?android:attr/textAppearanceSmall"
+              android:textColor="@color/signal_text_secondary"
+              android:text="@string/DeviceListItem_this_device"
+              android:fontFamily="sans-serif-light"  />
+
     <TextView android:id="@+id/created"
               android:layout_width="match_parent"
               android:layout_height="wrap_content"

--- a/app/src/main/res/layout/device_name.xml
+++ b/app/src/main/res/layout/device_name.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<EditText
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    tools:viewBindingIgnore="true"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/input"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:paddingTop="7dp"
+    android:paddingStart="16dp"
+    android:paddingEnd="16dp"
+    android:paddingBottom="16dp"
+    android:background="@color/transparent"
+    android:singleLine="true"
+    android:saveEnabled="false"
+    android:hint="@string/RegistrationActivity_device_name_description"
+    tools:text="Device Name" />

--- a/app/src/main/res/layout/fragment_registration_enter_phone_number.xml
+++ b/app/src/main/res/layout/fragment_registration_enter_phone_number.xml
@@ -112,8 +112,8 @@
             android:text="@android:string/cancel"
             android:visibility="gone"
             app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintStart_toStartOf="@id/registerButton"
+            app:layout_constraintEnd_toEndOf="@id/registerButton"
             tools:visibility="visible" />
 
         <org.thoughtcrime.securesms.util.views.CircularProgressMaterialButton
@@ -128,6 +128,21 @@
             app:layout_constraintBottom_toTopOf="@+id/cancel_button"
             app:layout_constraintEnd_toEndOf="parent"
             app:materialThemeOverlay="@style/ThemeOverlay.Signal.CircularProgressIndicator.Tonal" />
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/link_button"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="32dp"
+            android:layout_marginTop="16dp"
+            android:layout_marginEnd="32dp"
+            android:layout_marginBottom="16dp"
+            android:text="@string/RegistrationActivity_link_device"
+            style="@style/Signal.Widget.Button.Large.Secondary"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintHorizontal_bias="0.5"
+            app:layout_constraintVertical_bias="0" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 

--- a/app/src/main/res/layout/fragment_registration_link_device.xml
+++ b/app/src/main/res/layout/fragment_registration_link_device.xml
@@ -1,0 +1,99 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    tools:viewBindingIgnore="true"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/scroll_view"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:fillViewport="true"
+    tools:context=".registration.fragments.LinkDeviceFragment">
+
+    <LinearLayout
+        android:id="@+id/linearLayout"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical">
+
+        <TextView
+            android:id="@+id/verify_header"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center"
+            android:layout_marginStart="32dp"
+            android:layout_marginTop="40dp"
+            android:layout_marginEnd="32dp"
+            android:layout_marginBottom="16dp"
+            android:gravity="center"
+            android:textAppearance="@style/Signal.Text.HeadlineMedium"
+            android:text="@string/RegistrationActivity_scan_this_qr_using_your_primary_device" />
+
+        <ProgressBar
+            android:id="@+id/linking_loading_spinner"
+            android:layout_width="48dp"
+            android:layout_height="48dp"
+            android:layout_marginTop="16dp"
+            android:layout_marginBottom="16dp"
+            android:layout_gravity="center" />
+
+        <org.thoughtcrime.securesms.components.qr.QrView
+            android:id="@+id/linking_qr_image"
+            android:visibility="gone"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center"
+            android:scaleType="fitXY"
+            app:qr_background_color="@color/white"
+            app:qr_foreground_color="@color/black" />
+
+        <TextView
+            android:id="@+id/linking_text_code"
+            android:visibility="gone"
+            style="@style/Signal.Text.Body.Registration"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="16dp"
+            android:layout_marginBottom="16dp"
+            android:layout_gravity="center"
+            android:gravity="center"
+            android:fontFamily="serif-monospace" />
+
+        <TextView
+            android:id="@+id/linking_error"
+            android:visibility="gone"
+            style="@style/Signal.Text.Body.Registration"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="16dp"
+            android:layout_marginBottom="16dp"
+            android:layout_gravity="center"
+            android:gravity="center"
+            android:text="@string/RegistrationActivity_link_error" />
+
+        <TextView
+            android:id="@+id/linking_timeout"
+            android:visibility="gone"
+            style="@style/Signal.Text.Body.Registration"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="16dp"
+            android:layout_marginBottom="16dp"
+            android:layout_gravity="center"
+            android:gravity="center"
+            android:text="@string/RegistrationActivity_link_timeout" />
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/link_retry_button"
+            android:visibility="gone"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="32dp"
+            android:layout_marginEnd="32dp"
+            android:layout_marginTop="16dp"
+            android:layout_marginBottom="16dp"
+            android:text="@string/RegistrationActivity_link_retry"
+            style="@style/Signal.Widget.Button.Large.Primary" />
+
+    </LinearLayout>
+
+</ScrollView>

--- a/app/src/main/res/layout/fragment_registration_link_device_name.xml
+++ b/app/src/main/res/layout/fragment_registration_link_device_name.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    tools:viewBindingIgnore="true"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/scroll_view"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:fillViewport="true"
+    tools:context=".registration.fragments.LinkDeviceFragment">
+
+    <LinearLayout
+        android:id="@+id/linearLayout"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical">
+
+        <TextView
+            android:id="@+id/verify_header"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center"
+            android:layout_marginStart="32dp"
+            android:layout_marginTop="40dp"
+            android:layout_marginEnd="32dp"
+            android:layout_marginBottom="16dp"
+            android:gravity="center"
+            android:textAppearance="@style/Signal.Text.HeadlineMedium"
+            android:text="@string/RegistrationActivity_enter_a_name_for_this_device" />
+
+        <org.thoughtcrime.securesms.components.LabeledEditText
+            android:id="@+id/device_name"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="32dp"
+            android:layout_marginEnd="32dp"
+            android:layout_marginBottom="16dp"
+            app:labeledEditText_background="@color/white"
+            app:labeledEditText_label="@string/RegistrationActivity_device_name_description"
+            app:labeledEditText_textLayout="@layout/device_name" />
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/link_button"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="32dp"
+            android:layout_marginEnd="32dp"
+            android:layout_marginBottom="16dp"
+            android:text="@string/RegistrationActivity_link"
+            style="@style/Signal.Widget.Button.Large.Primary" />
+
+    </LinearLayout>
+
+</ScrollView>

--- a/app/src/main/res/navigation/registration.xml
+++ b/app/src/main/res/navigation/registration.xml
@@ -120,6 +120,14 @@
             app:popUpTo="@id/enterPhoneNumberFragment"
             app:popUpToInclusive="true" />
 
+        <action
+            android:id="@+id/action_linkDevice"
+            app:destination="@+id/linkDeviceNameFragment"
+            app:enterAnim="@anim/nav_default_enter_anim"
+            app:exitAnim="@anim/nav_default_exit_anim"
+            app:popEnterAnim="@anim/nav_default_pop_enter_anim"
+            app:popExitAnim="@anim/nav_default_pop_exit_anim" />
+
     </fragment>
 
     <fragment
@@ -289,6 +297,40 @@
             android:defaultValue="@null"
             app:argType="android.net.Uri"
             app:nullable="true" />
+
+    </fragment>
+
+    <fragment
+        android:id="@+id/linkDeviceNameFragment"
+        android:name="org.thoughtcrime.securesms.registration.fragments.LinkDeviceNameFragment"
+        android:label="fragment_link_device"
+        tools:layout="@layout/fragment_registration_link_device_name">
+
+        <action
+            android:id="@+id/action_linkDevice"
+            app:destination="@id/linkDeviceFragment"
+            app:enterAnim="@anim/nav_default_enter_anim"
+            app:exitAnim="@anim/nav_default_exit_anim"
+            app:popEnterAnim="@anim/nav_default_pop_enter_anim"
+            app:popExitAnim="@anim/nav_default_pop_exit_anim" />
+
+    </fragment>
+
+    <fragment
+        android:id="@+id/linkDeviceFragment"
+        android:name="org.thoughtcrime.securesms.registration.fragments.LinkDeviceFragment"
+        android:label="fragment_link_device"
+        tools:layout="@layout/fragment_registration_link_device">
+
+        <action
+            android:id="@+id/action_linkDeviceComplete"
+            app:destination="@id/registrationCompletePlaceHolderFragment"
+            app:enterAnim="@anim/nav_default_enter_anim"
+            app:exitAnim="@anim/nav_default_exit_anim"
+            app:popEnterAnim="@anim/nav_default_pop_enter_anim"
+            app:popExitAnim="@anim/nav_default_pop_exit_anim"
+            app:popUpTo="@+id/welcomeFragment"
+            app:popUpToInclusive="true" />
 
     </fragment>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -709,7 +709,10 @@
     <string name="DeviceListActivity_network_failed">Network failed!</string>
 
     <!-- DeviceListItem -->
-    <string name="DeviceListItem_unnamed_device">Unnamed device</string>
+    <string name="DeviceListItem_device_d">Device #%d</string>
+    <string name="DeviceListItem_primary">Primary</string>
+    <string name="DeviceListItem_this_device">This device</string>
+    <string name="DeviceListItem_registered_s">Registered %s</string>
     <string name="DeviceListItem_linked_s">Linked %s</string>
     <string name="DeviceListItem_last_active_s">Last active %s</string>
     <string name="DeviceListItem_today">Today</string>
@@ -1926,6 +1929,16 @@
     <!--    A clickable piece of text that will pre-fill a request for support email in the user\'s email app.-->
     <string name="RegistrationActivity_support_bottom_sheet_cta_contact_support_substring">Contact Support</string>
 
+    <string name="RegistrationActivity_link_device">Link to existing device</string>
+    <string name="RegistrationActivity_device_name_description">Device name</string>
+    <string name="RegistrationActivity_link">Link</string>
+    <string name="RegistrationActivity_enter_a_name_for_this_device">Enter a name for this device</string>
+    <string name="RegistrationActivity_scan_this_qr_using_your_primary_device">Scan this QR code using your primary device</string>
+    <string name="RegistrationActivity_copied_to_clipboard">Copied to clipboard</string>
+    <string name="RegistrationActivity_link_error">An error has occurred while trying to link the device. Check your network connectivity, and retry</string>
+    <string name="RegistrationActivity_link_timeout">Timed out waiting for the primary device. Ready your device to scan the QR code, then try again</string>
+    <string name="RegistrationActivity_link_retry">Retry linking</string>
+
     <!-- RegistrationLockV2Dialog -->
     <string name="RegistrationLockV2Dialog_turn_on_registration_lock">Turn on Registration Lock?</string>
     <string name="RegistrationLockV2Dialog_turn_off_registration_lock">Turn off Registration Lock?</string>
@@ -2544,7 +2557,6 @@
     <string name="device_link_fragment__link_device">Link device</string>
 
     <!-- device_list_fragment -->
-    <string name="device_list_fragment__no_devices_linked">No devices linked</string>
     <string name="device_list_fragment__link_new_device">Link new device</string>
 
     <!-- expiration -->
@@ -2952,6 +2964,7 @@
     <string name="preferences__request_keyboard_to_disable">Request keyboard to disable personalized learning.</string>
     <string name="preferences__this_setting_is_not_a_guarantee">This setting is not a guarantee, and your keyboard may ignore it.</string>
     <string name="preferences__incognito_keyboard_learn_more" translatable="false">https://support.signal.org/hc/articles/360055276112</string>
+    <string name="preferences__primary_only">This setting cannot be changed from a linked device</string>
     <string name="preferences_chats__when_using_mobile_data">When using mobile data</string>
     <string name="preferences_chats__when_using_wifi">When using Wi-Fi</string>
     <string name="preferences_chats__when_roaming">When roaming</string>

--- a/libsignal/service/src/main/java/org/whispersystems/signalservice/api/SignalServiceAccountManager.java
+++ b/libsignal/service/src/main/java/org/whispersystems/signalservice/api/SignalServiceAccountManager.java
@@ -9,12 +9,17 @@ package org.whispersystems.signalservice.api;
 
 import com.google.protobuf.ByteString;
 
+import org.signal.libsignal.protocol.IdentityKey;
 import org.signal.libsignal.protocol.IdentityKeyPair;
 import org.signal.libsignal.protocol.InvalidKeyException;
+import org.signal.libsignal.protocol.ecc.Curve;
+import org.signal.libsignal.protocol.ecc.ECPrivateKey;
 import org.signal.libsignal.protocol.ecc.ECPublicKey;
 import org.signal.libsignal.protocol.logging.Log;
 import org.signal.libsignal.protocol.state.SignedPreKeyRecord;
+import org.signal.libsignal.protocol.util.ByteUtil;
 import org.signal.libsignal.zkgroup.profiles.ExpiringProfileKeyCredential;
+import org.signal.libsignal.zkgroup.InvalidInputException;
 import org.signal.libsignal.zkgroup.profiles.ProfileKey;
 import org.whispersystems.signalservice.api.account.AccountAttributes;
 import org.whispersystems.signalservice.api.account.ChangePhoneNumberRequest;
@@ -60,8 +65,10 @@ import org.whispersystems.signalservice.internal.push.BackupAuthCheckRequest;
 import org.whispersystems.signalservice.internal.push.BackupAuthCheckResponse;
 import org.whispersystems.signalservice.internal.push.CdsiAuthResponse;
 import org.whispersystems.signalservice.internal.push.OneTimePreKeyCounts;
+import org.whispersystems.signalservice.internal.push.ConfirmCodeMessage;
 import org.whispersystems.signalservice.internal.push.ProfileAvatarData;
 import org.whispersystems.signalservice.internal.push.ProvisionMessage;
+import org.whispersystems.signalservice.internal.push.ProvisioningSocket;
 import org.whispersystems.signalservice.internal.push.ProvisioningVersion;
 import org.whispersystems.signalservice.internal.push.PushServiceSocket;
 import org.whispersystems.signalservice.internal.push.RegistrationSessionMetadataResponse;
@@ -77,6 +84,7 @@ import org.whispersystems.signalservice.internal.storage.protos.StorageItem;
 import org.whispersystems.signalservice.internal.storage.protos.StorageItems;
 import org.whispersystems.signalservice.internal.storage.protos.StorageManifest;
 import org.whispersystems.signalservice.internal.storage.protos.WriteOperation;
+import org.whispersystems.signalservice.internal.util.DynamicCredentialsProvider;
 import org.whispersystems.signalservice.internal.util.StaticCredentialsProvider;
 import org.whispersystems.signalservice.internal.util.Util;
 import org.whispersystems.signalservice.internal.websocket.DefaultResponseMapper;
@@ -119,6 +127,7 @@ public class SignalServiceAccountManager {
   private static final int STORAGE_READ_MAX_ITEMS = 1000;
 
   private final PushServiceSocket          pushServiceSocket;
+  private final ProvisioningSocket         provisioningSocket;
   private final CredentialsProvider        credentials;
   private final String                     userAgent;
   private final GroupsV2Operations         groupsV2Operations;
@@ -158,7 +167,8 @@ public class SignalServiceAccountManager {
                                      boolean automaticNetworkRetry)
   {
     this.groupsV2Operations = groupsV2Operations;
-    this.pushServiceSocket  = new PushServiceSocket(configuration, credentialsProvider, signalAgent, groupsV2Operations.getProfileOperations(), automaticNetworkRetry);
+    this.pushServiceSocket  = new PushServiceSocket(configuration, credentialsProvider, signalAgent, groupsV2Operations == null ? null : groupsV2Operations.getProfileOperations(), automaticNetworkRetry);
+    this.provisioningSocket = new ProvisioningSocket(configuration, signalAgent);
     this.credentials        = credentialsProvider;
     this.userAgent          = signalAgent;
     this.configuration      = configuration;
@@ -380,6 +390,17 @@ public class SignalServiceAccountManager {
    */
   public boolean isIdentifierRegistered(ServiceId identifier) throws IOException {
     return pushServiceSocket.isIdentifierRegistered(identifier);
+  }
+
+  /**
+   * Request a UUID from the server for linking as a new device.
+   * Called by the new device.
+   * @return The UUID, Base64 encoded
+   * @throws TimeoutException
+   * @throws IOException
+   */
+  public String getNewDeviceUuid() throws TimeoutException, IOException {
+    return provisioningSocket.getProvisioningUuid().uuid;
   }
 
   @SuppressWarnings("SameParameterValue")
@@ -644,6 +665,81 @@ public class SignalServiceAccountManager {
     return this.pushServiceSocket.getNewDeviceVerificationCode();
   }
 
+  /**
+   * Gets info from the primary device to finish the registration as a new device.<br>
+   * @param tempIdentity A temporary identity. Must be the same as the one given to the already verified device.
+   * @return Contains the account's permanent IdentityKeyPair and it's number along with the provisioning code required to finish the registration.
+   */
+  public NewDeviceRegistrationReturn getNewDeviceRegistration(IdentityKeyPair tempIdentity) throws TimeoutException, IOException {
+    ProvisionMessage msg = provisioningSocket.getProvisioningMessage(tempIdentity);
+
+    final String number = msg.number;
+    final ACI    aci    = ACI.parseOrNull(msg.aci);
+    final PNI    pni    = PNI.parseOrNull(msg.pni);
+
+    if (credentials instanceof DynamicCredentialsProvider) {
+      ((DynamicCredentialsProvider) credentials).setE164(number);
+    }
+    // Not setting Uuid here, as that causes a 400 Bad Request
+    // when calling the finishNewDeviceRegistration endpoint
+    // credentialsProvider.setUuid(uuid);
+
+    final IdentityKeyPair aciIdentity = getIdentityKeyPair(msg.aciIdentityKeyPublic.toByteArray(), msg.aciIdentityKeyPrivate.toByteArray());
+    final IdentityKeyPair pniIdentity = msg.pniIdentityKeyPublic != null && msg.pniIdentityKeyPrivate != null
+                                        ? getIdentityKeyPair(msg.pniIdentityKeyPublic.toByteArray(), msg.pniIdentityKeyPrivate.toByteArray())
+                                        : null;
+
+    final ProfileKey profileKey;
+    try {
+      profileKey = msg.profileKey != null ? new ProfileKey(msg.profileKey.toByteArray()) : null;
+    } catch (InvalidInputException e) {
+      throw new IOException("Failed to decrypt profile key", e);
+    }
+
+    final String  provisioningCode = msg.provisioningCode;
+    final boolean readReceipts     = msg.readReceipts != null && msg.readReceipts;
+
+    return new NewDeviceRegistrationReturn(
+        provisioningCode,
+        aciIdentity, pniIdentity,
+        number, aci, pni,
+        profileKey,
+        readReceipts
+    );
+  }
+
+  private IdentityKeyPair getIdentityKeyPair(byte[] publicKeyBytes, byte[] privateKeyBytes) throws IOException {
+    if (publicKeyBytes.length == 32) {
+      // The public key is missing the type specifier, probably from iOS
+      // Signal-Desktop handles this by ignoring the sent public key and regenerating it from the private key
+      byte[] type = {Curve.DJB_TYPE};
+      publicKeyBytes = ByteUtil.combine(type, publicKeyBytes);
+    }
+    final ECPublicKey publicKey;
+    final ECPrivateKey    privateKey;
+    try {
+      publicKey = Curve.decodePoint(publicKeyBytes, 0);
+      privateKey = Curve.decodePrivatePoint(privateKeyBytes);
+    } catch (InvalidKeyException e) {
+      throw new IOException("Failed to decrypt key", e);
+    }
+    return new IdentityKeyPair(new IdentityKey(publicKey), privateKey);
+  }
+
+  /**
+   * Finishes a registration as a new device. Called by the new device.<br>
+   * This method blocks until the already verified device has verified this device.
+   * @param provisioningCode The provisioning code from the getNewDeviceRegistration method
+   * @return The deviceId given by the server.
+   */
+  public int finishNewDeviceRegistration(String provisioningCode, ConfirmCodeMessage confirmCodeMessage) throws IOException {
+    int deviceId = this.pushServiceSocket.finishNewDeviceRegistration(provisioningCode, confirmCodeMessage);
+    if (credentials instanceof DynamicCredentialsProvider) {
+      ((DynamicCredentialsProvider) credentials).setDeviceId(deviceId);
+    }
+    return deviceId;
+  }
+
   public void addDevice(String deviceIdentifier,
                         ECPublicKey deviceKey,
                         IdentityKeyPair aciIdentityKeyPair,
@@ -835,6 +931,81 @@ public class SignalServiceAccountManager {
 
   public GroupsV2Api getGroupsV2Api() {
     return new GroupsV2Api(pushServiceSocket, groupsV2Operations);
+  }
+
+  /**
+   * Helper class for holding the returns of getNewDeviceRegistration()
+   */
+  public static class NewDeviceRegistrationReturn {
+    private final String          provisioningCode;
+    private final IdentityKeyPair aciIdentity;
+    private final IdentityKeyPair pniIdentity;
+    private final String          number;
+    private final ACI             aci;
+    private final PNI             pni;
+    private final ProfileKey      profileKey;
+    private final boolean         readReceipts;
+
+    NewDeviceRegistrationReturn(String provisioningCode, IdentityKeyPair aciIdentity, IdentityKeyPair pniIdentity, String number, ACI aci, PNI pni, ProfileKey profileKey, boolean readReceipts) {
+      this.provisioningCode = provisioningCode;
+      this.aciIdentity      = aciIdentity;
+      this.pniIdentity      = pniIdentity;
+      this.number           = number;
+      this.aci              = aci;
+      this.pni              = pni;
+      this.profileKey       = profileKey;
+      this.readReceipts     = readReceipts;
+    }
+
+    /**
+     * @return The provisioning code to finish the new device registration
+     */
+    public String getProvisioningCode() {
+      return provisioningCode;
+    }
+
+    /**
+     * @return The account's permanent IdentityKeyPair
+     */
+    public IdentityKeyPair getAciIdentity() {
+      return aciIdentity;
+    }
+
+    public IdentityKeyPair getPniIdentity() {
+      return pniIdentity;
+    }
+
+    /**
+     * @return The account's number
+     */
+    public String getNumber() {
+      return number;
+    }
+
+    /**
+     * @return The account's uuid
+     */
+    public ACI getAci() {
+      return aci;
+    }
+
+    public PNI getPni() {
+      return pni;
+    }
+
+    /**
+     * @return The account's profile key or null
+     */
+    public ProfileKey getProfileKey() {
+      return profileKey;
+    }
+
+    /**
+     * @return The account's read receipts setting
+     */
+    public boolean isReadReceipts() {
+      return readReceipts;
+    }
   }
 
   public AuthCredentials getPaymentsAuthorization() throws IOException {

--- a/libsignal/service/src/main/java/org/whispersystems/signalservice/api/messages/multidevice/SignalServiceSyncMessage.java
+++ b/libsignal/service/src/main/java/org/whispersystems/signalservice/api/messages/multidevice/SignalServiceSyncMessage.java
@@ -11,6 +11,7 @@ import org.whispersystems.signalservice.internal.push.SignalServiceProtos;
 import org.whispersystems.signalservice.internal.push.SignalServiceProtos.SyncMessage.CallEvent;
 import org.whispersystems.signalservice.internal.push.SignalServiceProtos.SyncMessage.CallLinkUpdate;
 import org.whispersystems.signalservice.internal.push.SignalServiceProtos.SyncMessage.CallLogEvent;
+import org.whispersystems.signalservice.internal.push.SignalServiceProtos.SyncMessage.PniChangeNumber;
 
 import java.util.LinkedList;
 import java.util.List;
@@ -34,6 +35,7 @@ public class SignalServiceSyncMessage {
   private final Optional<MessageRequestResponseMessage>     messageRequestResponse;
   private final Optional<OutgoingPaymentMessage>            outgoingPaymentMessage;
   private final Optional<List<ViewedMessage>>               views;
+  private final Optional<PniChangeNumber>                   pniChangeNumber;
   private final Optional<CallEvent>                         callEvent;
   private final Optional<CallLinkUpdate>                    callLinkUpdate;
   private final Optional<CallLogEvent>                      callLogEvent;
@@ -52,6 +54,7 @@ public class SignalServiceSyncMessage {
                                    Optional<MessageRequestResponseMessage> messageRequestResponse,
                                    Optional<OutgoingPaymentMessage> outgoingPaymentMessage,
                                    Optional<List<ViewedMessage>> views,
+                                   Optional<PniChangeNumber> pniChangeNumber,
                                    Optional<CallEvent> callEvent,
                                    Optional<CallLinkUpdate> callLinkUpdate,
                                    Optional<CallLogEvent> callLogEvent)
@@ -70,6 +73,7 @@ public class SignalServiceSyncMessage {
     this.messageRequestResponse = messageRequestResponse;
     this.outgoingPaymentMessage = outgoingPaymentMessage;
     this.views                  = views;
+    this.pniChangeNumber        = pniChangeNumber;
     this.callEvent              = callEvent;
     this.callLinkUpdate         = callLinkUpdate;
     this.callLogEvent           = callLogEvent;
@@ -77,6 +81,7 @@ public class SignalServiceSyncMessage {
 
   public static SignalServiceSyncMessage forSentTranscript(SentTranscriptMessage sent) {
     return new SignalServiceSyncMessage(Optional.of(sent),
+                                        Optional.empty(),
                                         Optional.empty(),
                                         Optional.empty(),
                                         Optional.empty(),
@@ -112,6 +117,7 @@ public class SignalServiceSyncMessage {
                                         Optional.empty(),
                                         Optional.empty(),
                                         Optional.empty(),
+                                        Optional.empty(),
                                         Optional.empty());
   }
 
@@ -120,6 +126,7 @@ public class SignalServiceSyncMessage {
                                         Optional.empty(),
                                         Optional.empty(),
                                         Optional.of(request),
+                                        Optional.empty(),
                                         Optional.empty(),
                                         Optional.empty(),
                                         Optional.empty(),
@@ -152,6 +159,7 @@ public class SignalServiceSyncMessage {
                                         Optional.empty(),
                                         Optional.empty(),
                                         Optional.empty(),
+                                        Optional.empty(),
                                         Optional.empty());
   }
 
@@ -172,6 +180,7 @@ public class SignalServiceSyncMessage {
                                         Optional.of(views),
                                         Optional.empty(),
                                         Optional.empty(),
+                                        Optional.empty(),
                                         Optional.empty());
   }
 
@@ -182,6 +191,7 @@ public class SignalServiceSyncMessage {
                                         Optional.empty(),
                                         Optional.empty(),
                                         Optional.of(timerRead),
+                                        Optional.empty(),
                                         Optional.empty(),
                                         Optional.empty(),
                                         Optional.empty(),
@@ -215,6 +225,7 @@ public class SignalServiceSyncMessage {
                                         Optional.empty(),
                                         Optional.empty(),
                                         Optional.empty(),
+                                        Optional.empty(),
                                         Optional.empty());
   }
 
@@ -235,6 +246,7 @@ public class SignalServiceSyncMessage {
                                         Optional.empty(),
                                         Optional.empty(),
                                         Optional.empty(),
+                                        Optional.empty(),
                                         Optional.empty());
   }
 
@@ -242,6 +254,7 @@ public class SignalServiceSyncMessage {
     return new SignalServiceSyncMessage(Optional.empty(),
                                         Optional.empty(),
                                         Optional.of(blocked),
+                                        Optional.empty(),
                                         Optional.empty(),
                                         Optional.empty(),
                                         Optional.empty(),
@@ -275,6 +288,7 @@ public class SignalServiceSyncMessage {
                                         Optional.empty(),
                                         Optional.empty(),
                                         Optional.empty(),
+                                        Optional.empty(),
                                         Optional.empty());
   }
 
@@ -288,6 +302,7 @@ public class SignalServiceSyncMessage {
                                         Optional.empty(),
                                         Optional.empty(),
                                         Optional.of(stickerPackOperations),
+                                        Optional.empty(),
                                         Optional.empty(),
                                         Optional.empty(),
                                         Optional.empty(),
@@ -315,6 +330,7 @@ public class SignalServiceSyncMessage {
                                         Optional.empty(),
                                         Optional.empty(),
                                         Optional.empty(),
+                                        Optional.empty(),
                                         Optional.empty());
   }
 
@@ -330,6 +346,7 @@ public class SignalServiceSyncMessage {
                                         Optional.empty(),
                                         Optional.empty(),
                                         Optional.of(keys),
+                                        Optional.empty(),
                                         Optional.empty(),
                                         Optional.empty(),
                                         Optional.empty(),
@@ -355,6 +372,7 @@ public class SignalServiceSyncMessage {
                                         Optional.empty(),
                                         Optional.empty(),
                                         Optional.empty(),
+                                        Optional.empty(),
                                         Optional.empty());
   }
 
@@ -375,11 +393,34 @@ public class SignalServiceSyncMessage {
                                         Optional.empty(),
                                         Optional.empty(),
                                         Optional.empty(),
+                                        Optional.empty(),
+                                        Optional.empty());
+  }
+
+  public static SignalServiceSyncMessage forPniChangeNumber(PniChangeNumber pniChangeNumber) {
+    return new SignalServiceSyncMessage(Optional.empty(),
+                                        Optional.empty(),
+                                        Optional.empty(),
+                                        Optional.empty(),
+                                        Optional.empty(),
+                                        Optional.empty(),
+                                        Optional.empty(),
+                                        Optional.empty(),
+                                        Optional.empty(),
+                                        Optional.empty(),
+                                        Optional.empty(),
+                                        Optional.empty(),
+                                        Optional.empty(),
+                                        Optional.empty(),
+                                        Optional.of(pniChangeNumber),
+                                        Optional.empty(),
+                                        Optional.empty(),
                                         Optional.empty());
   }
 
   public static SignalServiceSyncMessage forCallEvent(@Nonnull CallEvent callEvent) {
     return new SignalServiceSyncMessage(Optional.empty(),
+                                        Optional.empty(),
                                         Optional.empty(),
                                         Optional.empty(),
                                         Optional.empty(),
@@ -400,6 +441,7 @@ public class SignalServiceSyncMessage {
 
   public static SignalServiceSyncMessage forCallLinkUpdate(@Nonnull CallLinkUpdate callLinkUpdate) {
     return new SignalServiceSyncMessage(Optional.empty(),
+                                        Optional.empty(),
                                         Optional.empty(),
                                         Optional.empty(),
                                         Optional.empty(),
@@ -435,11 +477,13 @@ public class SignalServiceSyncMessage {
                                         Optional.empty(),
                                         Optional.empty(),
                                         Optional.empty(),
+                                        Optional.empty(),
                                         Optional.of(callLogEvent));
   }
 
   public static SignalServiceSyncMessage empty() {
     return new SignalServiceSyncMessage(Optional.empty(),
+                                        Optional.empty(),
                                         Optional.empty(),
                                         Optional.empty(),
                                         Optional.empty(),
@@ -512,6 +556,10 @@ public class SignalServiceSyncMessage {
 
   public Optional<List<ViewedMessage>> getViewed() {
     return views;
+  }
+
+  public Optional<PniChangeNumber> getPniChangeNumber() {
+    return pniChangeNumber;
   }
 
   public Optional<CallEvent> getCallEvent() {

--- a/libsignal/service/src/main/java/org/whispersystems/signalservice/api/util/DeviceNameUtil.java
+++ b/libsignal/service/src/main/java/org/whispersystems/signalservice/api/util/DeviceNameUtil.java
@@ -1,0 +1,111 @@
+package org.whispersystems.signalservice.api.util;
+
+import com.google.protobuf.ByteString;
+
+import org.signal.libsignal.protocol.InvalidKeyException;
+import org.signal.libsignal.protocol.ecc.Curve;
+import org.signal.libsignal.protocol.ecc.ECKeyPair;
+import org.signal.libsignal.protocol.ecc.ECPrivateKey;
+import org.signal.libsignal.protocol.ecc.ECPublicKey;
+import org.signal.libsignal.protocol.util.ByteUtil;
+import org.whispersystems.signalservice.internal.devices.DeviceNameProtos.DeviceName;
+import org.whispersystems.signalservice.internal.util.Util;
+import org.whispersystems.util.Base64;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.security.GeneralSecurityException;
+import java.security.MessageDigest;
+
+import javax.crypto.Cipher;
+import javax.crypto.Mac;
+import javax.crypto.spec.IvParameterSpec;
+import javax.crypto.spec.SecretKeySpec;
+
+public final class DeviceNameUtil {
+  public static String encryptDeviceName(String plainTextDeviceName, ECPrivateKey identityKey) {
+    final byte[] plainText = plainTextDeviceName.getBytes(StandardCharsets.UTF_8);
+
+    ECKeyPair ephemeralKeyPair = Curve.generateKeyPair();
+
+    try {
+      Mac    mac    = Mac.getInstance("HmacSHA256");
+      Cipher cipher = Cipher.getInstance("AES/CTR/NoPadding");
+
+      byte[] masterSecret = Curve.calculateAgreement(ephemeralKeyPair.getPublicKey(), identityKey);
+
+      mac.init(new SecretKeySpec(masterSecret, "HmacSHA256"));
+      byte[] key1 = mac.doFinal("auth".getBytes());
+
+      mac.init(new SecretKeySpec(key1, "HmacSHA256"));
+      byte[] syntheticIv = ByteUtil.trim(mac.doFinal(plainText), 16);
+
+      mac.init(new SecretKeySpec(masterSecret, "HmacSHA256"));
+      byte[] key2 = mac.doFinal("cipher".getBytes());
+
+      mac.init(new SecretKeySpec(key2, "HmacSHA256"));
+      byte[] cipherKey = mac.doFinal(syntheticIv);
+
+      cipher.init(Cipher.ENCRYPT_MODE, new SecretKeySpec(cipherKey, "AES"), new IvParameterSpec(new byte[16]));
+      final byte[] cipherText = cipher.doFinal(plainText);
+
+      final DeviceName deviceName = DeviceName
+          .newBuilder()
+          .setCiphertext(ByteString.copyFrom(cipherText))
+          .setEphemeralPublic(ByteString.copyFrom(ephemeralKeyPair.getPublicKey().serialize()))
+          .setSyntheticIv(ByteString.copyFrom(syntheticIv))
+          .build();
+
+      return Base64.encodeBytes(deviceName.toByteArray());
+    } catch (InvalidKeyException | GeneralSecurityException e) {
+      throw new AssertionError(e);
+    }
+  }
+
+  public static String decryptDeviceName(String encryptedDeviceName, ECPrivateKey identityKey) throws IOException {
+    if (Util.isEmpty(encryptedDeviceName) || encryptedDeviceName.length() < 4) {
+      throw new IOException("Invalid DeviceInfo name.");
+    }
+
+    DeviceName deviceName = DeviceName.parseFrom(Base64.decode(encryptedDeviceName));
+
+    if (!deviceName.hasCiphertext() || !deviceName.hasEphemeralPublic() || !deviceName.hasSyntheticIv()) {
+      throw new IOException("Got a DeviceName that wasn't properly populated.");
+    }
+
+    byte[] syntheticIv          = deviceName.getSyntheticIv().toByteArray();
+    byte[] cipherText           = deviceName.getCiphertext().toByteArray();
+    byte[] ephemeralPublicBytes = deviceName.getEphemeralPublic().toByteArray();
+
+    try {
+      ECPublicKey ephemeralPublic = Curve.decodePoint(ephemeralPublicBytes, 0);
+      byte[]      masterSecret    = Curve.calculateAgreement(ephemeralPublic, identityKey);
+
+      Mac mac = Mac.getInstance("HmacSHA256");
+      mac.init(new SecretKeySpec(masterSecret, "HmacSHA256"));
+      byte[] cipherKeyPart1 = mac.doFinal("cipher".getBytes());
+
+      mac.init(new SecretKeySpec(cipherKeyPart1, "HmacSHA256"));
+      byte[] cipherKey = mac.doFinal(syntheticIv);
+
+      Cipher cipher = Cipher.getInstance("AES/CTR/NoPadding");
+      cipher.init(Cipher.DECRYPT_MODE, new SecretKeySpec(cipherKey, "AES"), new IvParameterSpec(new byte[16]));
+      final byte[] plaintext = cipher.doFinal(cipherText);
+
+      mac.init(new SecretKeySpec(masterSecret, "HmacSHA256"));
+      byte[] verificationPart1 = mac.doFinal("auth".getBytes());
+
+      mac.init(new SecretKeySpec(verificationPart1, "HmacSHA256"));
+      byte[] verificationPart2 = mac.doFinal(plaintext);
+      byte[] ourSyntheticIv    = ByteUtil.trim(verificationPart2, 16);
+
+      if (!MessageDigest.isEqual(ourSyntheticIv, syntheticIv)) {
+        throw new GeneralSecurityException("The computed syntheticIv didn't match the actual syntheticIv.");
+      }
+
+      return new String(plaintext, StandardCharsets.UTF_8);
+    } catch (InvalidKeyException | GeneralSecurityException e) {
+      throw new IOException("Failed to decrypt device name", e);
+    }
+  }
+}

--- a/libsignal/service/src/main/java/org/whispersystems/signalservice/internal/crypto/PrimaryProvisioningCipher.java
+++ b/libsignal/service/src/main/java/org/whispersystems/signalservice/internal/crypto/PrimaryProvisioningCipher.java
@@ -6,6 +6,7 @@
 
 package org.whispersystems.signalservice.internal.crypto;
 
+import org.signal.libsignal.protocol.IdentityKeyPair;
 import org.signal.libsignal.protocol.InvalidKeyException;
 import org.signal.libsignal.protocol.ecc.Curve;
 import org.signal.libsignal.protocol.ecc.ECKeyPair;
@@ -15,13 +16,17 @@ import org.whispersystems.signalservice.internal.push.ProvisionEnvelope;
 import org.whispersystems.signalservice.internal.push.ProvisionMessage;
 import org.whispersystems.signalservice.internal.util.Util;
 
+import java.io.IOException;
+import java.security.InvalidAlgorithmParameterException;
 import java.security.NoSuchAlgorithmException;
+import java.util.Arrays;
 
 import javax.crypto.BadPaddingException;
 import javax.crypto.Cipher;
 import javax.crypto.IllegalBlockSizeException;
 import javax.crypto.Mac;
 import javax.crypto.NoSuchPaddingException;
+import javax.crypto.spec.IvParameterSpec;
 import javax.crypto.spec.SecretKeySpec;
 
 import okio.ByteString;
@@ -72,6 +77,43 @@ public class PrimaryProvisioningCipher {
 
       return mac.doFinal(message);
     } catch (NoSuchAlgorithmException | java.security.InvalidKeyException e) {
+      throw new AssertionError(e);
+    }
+  }
+
+  public ProvisionMessage decrypt(IdentityKeyPair tempIdentity, byte[] bytes) throws InvalidKeyException, IOException {
+    ProvisionEnvelope envelope      = ProvisionEnvelope.ADAPTER.decode(bytes);
+    ECPublicKey       publicKey     = Curve.decodePoint(envelope.publicKey.toByteArray(), 0);
+    byte[]            sharedSecret  = Curve.calculateAgreement(publicKey, tempIdentity.getPrivateKey());
+    byte[]            derivedSecret = HKDF.deriveSecrets(sharedSecret, PROVISIONING_MESSAGE.getBytes(), 64);
+    byte[][]          parts         = Util.split(derivedSecret, 32, 32);
+    ByteString        joined        = envelope.body;
+    if (joined.getByte(0) != 0x01) {
+      throw new RuntimeException("Bad version number on provision message!");
+    }
+    byte[] iv              = joined.substring(1, 16 + 1).toByteArray();
+    byte[] ciphertext      = joined.substring(16 + 1, joined.size() - 32).toByteArray();
+    byte[] ivAndCiphertext = joined.substring(0, joined.size() - 32).toByteArray();
+    byte[] mac             = joined.substring(joined.size() - 32).toByteArray();
+
+    verifyMac(parts[1], ivAndCiphertext, mac);
+
+    return ProvisionMessage.ADAPTER.decode(decrypt(parts[0], iv, ciphertext));
+  }
+
+  private void verifyMac(byte[] key, byte[] message, byte[] theirMac) {
+    byte[] ourMac = getMac(key, message);
+    if (!Arrays.equals(ourMac, theirMac)) {
+      throw new RuntimeException("Invalid MAC on provision message!");
+    }
+  }
+
+  private byte[] decrypt(byte[] key, byte[] iv, byte[] ciphertext) {
+    try {
+      Cipher cipher = Cipher.getInstance("AES/CBC/PKCS5Padding");
+      cipher.init(Cipher.DECRYPT_MODE, new SecretKeySpec(key, "AES"), new IvParameterSpec(iv));
+      return cipher.doFinal(ciphertext);
+    } catch (java.security.InvalidKeyException | NoSuchAlgorithmException | NoSuchPaddingException | InvalidAlgorithmParameterException | IllegalBlockSizeException | BadPaddingException e) {
       throw new AssertionError(e);
     }
   }

--- a/libsignal/service/src/main/java/org/whispersystems/signalservice/internal/push/ConfirmCodeMessage.java
+++ b/libsignal/service/src/main/java/org/whispersystems/signalservice/internal/push/ConfirmCodeMessage.java
@@ -1,0 +1,35 @@
+package org.whispersystems.signalservice.internal.push;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import org.whispersystems.signalservice.api.account.AccountAttributes.Capabilities;
+
+public class ConfirmCodeMessage {
+
+  @JsonProperty
+  private boolean supportsSms;
+
+  @JsonProperty
+  private boolean fetchesMessages;
+
+  @JsonProperty
+  private int registrationId;
+
+  @JsonProperty
+  private int pniRegistrationId;
+
+  @JsonProperty
+  private String name;
+
+  @JsonProperty
+  private Capabilities capabilities;
+
+  public ConfirmCodeMessage(boolean supportsSms, boolean fetchesMessages, int registrationId, int pniRegistrationId, String name, Capabilities capabilities) {
+    this.supportsSms = supportsSms;
+    this.fetchesMessages = fetchesMessages;
+    this.registrationId = registrationId;
+    this.pniRegistrationId = pniRegistrationId;
+    this.name = name;
+    this.capabilities = capabilities;
+  }
+}

--- a/libsignal/service/src/main/java/org/whispersystems/signalservice/internal/push/DeviceId.java
+++ b/libsignal/service/src/main/java/org/whispersystems/signalservice/internal/push/DeviceId.java
@@ -1,0 +1,14 @@
+package org.whispersystems.signalservice.internal.push;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class DeviceId {
+
+  @JsonProperty
+  private int deviceId;
+
+  public int getDeviceId() {
+    return deviceId;
+  }
+
+}

--- a/libsignal/service/src/main/java/org/whispersystems/signalservice/internal/push/ProvisioningSocket.java
+++ b/libsignal/service/src/main/java/org/whispersystems/signalservice/internal/push/ProvisioningSocket.java
@@ -1,0 +1,76 @@
+package org.whispersystems.signalservice.internal.push;
+
+import okio.ByteString;
+
+import org.signal.libsignal.protocol.IdentityKeyPair;
+import org.signal.libsignal.protocol.InvalidKeyException;
+import org.whispersystems.signalservice.api.websocket.HealthMonitor;
+import org.whispersystems.signalservice.internal.configuration.SignalServiceConfiguration;
+import org.whispersystems.signalservice.internal.crypto.PrimaryProvisioningCipher;
+import org.whispersystems.signalservice.internal.push.ProvisionMessage;
+import org.whispersystems.signalservice.internal.push.ProvisioningUuid;
+import org.whispersystems.signalservice.internal.websocket.WebSocketConnection;
+import org.whispersystems.signalservice.internal.websocket.WebSocketRequestMessage;
+
+import java.io.IOException;
+import java.util.Optional;
+import java.util.concurrent.TimeoutException;
+
+public class ProvisioningSocket {
+
+  private WebSocketConnection connection;
+  private boolean             connected = false;
+
+  public ProvisioningSocket(SignalServiceConfiguration signalServiceConfiguration, String userAgent) {
+    connection = new WebSocketConnection(
+        "provisioning",
+        signalServiceConfiguration,
+        Optional.empty(),
+        userAgent,
+        new HealthMonitor() {
+          @Override
+          public void onKeepAliveResponse(long sentTimestamp, boolean isIdentifiedWebSocket) {
+          }
+
+          @Override
+          public void onMessageError(int status, boolean isIdentifiedWebSocket) {
+          }
+        },
+        "provisioning/",
+        false
+    );
+  }
+
+  public ProvisioningUuid getProvisioningUuid() throws TimeoutException, IOException {
+    if (!connected) {
+      connection.connect();
+      connected = true;
+    }
+    ByteString       bytes = readRequest();
+    ProvisioningUuid msg   = ProvisioningUuid.ADAPTER.decode(bytes);
+    return msg;
+  }
+
+  public ProvisionMessage getProvisioningMessage(IdentityKeyPair tempIdentity) throws TimeoutException, IOException {
+    if (!connected) {
+      throw new IllegalStateException("No UUID requested yet!");
+    }
+    ByteString bytes = readRequest();
+    connection.disconnect();
+    connected = false;
+    ProvisionMessage msg;
+    try {
+      msg = new PrimaryProvisioningCipher(null).decrypt(tempIdentity, bytes.toByteArray());
+      return msg;
+    } catch (InvalidKeyException e) {
+      throw new AssertionError(e);
+    }
+  }
+
+  private ByteString readRequest() throws TimeoutException, IOException {
+    WebSocketRequestMessage response = connection.readRequest(100000);
+    ByteString              bytes    = response.body;
+    return bytes;
+  }
+
+}

--- a/libsignal/service/src/main/java/org/whispersystems/signalservice/internal/push/PushServiceSocket.java
+++ b/libsignal/service/src/main/java/org/whispersystems/signalservice/internal/push/PushServiceSocket.java
@@ -491,6 +491,13 @@ public class PushServiceSocket {
     makeServiceRequest(SET_ACCOUNT_ATTRIBUTES, "PUT", JsonUtil.toJson(accountAttributes));
   }
 
+  public int finishNewDeviceRegistration(String code, ConfirmCodeMessage confirmCodeMessage) throws IOException {
+    String json = JsonUtil.toJson(confirmCodeMessage);
+    String responseText = makeServiceRequest(String.format(DEVICE_PATH, code), "PUT", json);
+    DeviceId response = JsonUtil.fromJson(responseText, DeviceId.class);
+    return response.getDeviceId();
+  }
+
   public String getNewDeviceVerificationCode() throws IOException {
     String responseText = makeServiceRequest(PROVISIONING_CODE_PATH, "GET", null);
     return JsonUtil.fromJson(responseText, DeviceCode.class).getVerificationCode();

--- a/libsignal/service/src/main/java/org/whispersystems/signalservice/internal/push/SignalServiceEnvelopeEntity.java
+++ b/libsignal/service/src/main/java/org/whispersystems/signalservice/internal/push/SignalServiceEnvelopeEntity.java
@@ -41,6 +41,9 @@ public class SignalServiceEnvelopeEntity {
   private Boolean urgent;
 
   @JsonProperty
+  private String updatedPni;
+
+  @JsonProperty
   private Boolean story;
 
   @JsonProperty
@@ -98,6 +101,10 @@ public class SignalServiceEnvelopeEntity {
 
   public boolean isUrgent() {
     return urgent == null || urgent;
+  }
+
+  public String getUpdatedPni() {
+    return updatedPni;
   }
 
   public boolean isStory() {

--- a/libsignal/service/src/main/java/org/whispersystems/signalservice/internal/util/DynamicCredentialsProvider.java
+++ b/libsignal/service/src/main/java/org/whispersystems/signalservice/internal/util/DynamicCredentialsProvider.java
@@ -1,0 +1,69 @@
+package org.whispersystems.signalservice.internal.util;
+
+import org.whispersystems.signalservice.api.push.ServiceId.ACI;
+import org.whispersystems.signalservice.api.push.ServiceId.PNI;
+import org.whispersystems.signalservice.api.util.CredentialsProvider;
+
+import java.util.UUID;
+
+public class DynamicCredentialsProvider implements CredentialsProvider {
+
+  private ACI    aci;
+  private PNI    pni;
+  private String e164;
+  private String password;
+  private int    deviceId;
+
+  public DynamicCredentialsProvider(ACI aci, PNI pni, String e164, String password, int deviceId) {
+    this.aci = aci;
+    this.pni = pni;
+    this.e164 = e164;
+    this.password = password;
+    this.deviceId = deviceId;
+  }
+
+  @Override
+  public ACI getAci() {
+    return aci;
+  }
+
+  public void setAci(ACI aci) {
+    this.aci = aci;
+  }
+
+  @Override
+  public PNI getPni() {
+    return pni;
+  }
+
+  public void setPni(PNI pni) {
+    this.pni = pni;
+  }
+
+  @Override
+  public String getE164() {
+    return e164;
+  }
+
+  public void setE164(String e164) {
+    this.e164 = e164;
+  }
+
+  @Override
+  public String getPassword() {
+    return password;
+  }
+
+  public void setPassword(String password) {
+    this.password = password;
+  }
+
+  @Override
+  public int getDeviceId() {
+    return deviceId;
+  }
+
+  public void setDeviceId(int deviceId) {
+    this.deviceId = deviceId;
+  }
+}

--- a/libsignal/service/src/main/java/org/whispersystems/signalservice/internal/websocket/WebSocketConnection.java
+++ b/libsignal/service/src/main/java/org/whispersystems/signalservice/internal/websocket/WebSocketConnection.java
@@ -73,6 +73,7 @@ public class WebSocketConnection extends WebSocketListener {
   private final boolean                                   allowStories;
   private final SignalServiceUrl                          serviceUrl;
 
+  private OkHttpClient okHttpClient;
   private WebSocket client;
 
   public WebSocketConnection(String name,
@@ -149,7 +150,7 @@ public class WebSocketConnection extends WebSocketListener {
         clientBuilder.addInterceptor(interceptor);
       }
 
-      OkHttpClient okHttpClient = clientBuilder.build();
+      okHttpClient = clientBuilder.build();
 
       Request.Builder requestBuilder = new Request.Builder().url(filledUri);
 
@@ -332,6 +333,11 @@ public class WebSocketConnection extends WebSocketListener {
     }
 
     cleanupAfterShutdown();
+
+    if (okHttpClient != null ) {
+      okHttpClient.dispatcher().executorService().shutdown();
+      okHttpClient = null;
+    }
 
     notifyAll();
   }

--- a/libsignal/service/src/main/proto/DeviceName.proto
+++ b/libsignal/service/src/main/proto/DeviceName.proto
@@ -1,0 +1,18 @@
+/**
+ * Copyright (C) 2014-2016 Open Whisper Systems
+ *
+ * Licensed according to the LICENSE file in this repository.
+ */
+
+syntax = "proto2";
+
+package signalservice;
+
+option java_package         = "org.whispersystems.signalservice.internal.devices";
+option java_outer_classname = "DeviceNameProtos";
+
+message DeviceName {
+  optional bytes ephemeralPublic = 1;
+  optional bytes syntheticIv     = 2;
+  optional bytes ciphertext      = 3;
+}

--- a/libsignal/service/src/main/proto/SignalService.proto
+++ b/libsignal/service/src/main/proto/SignalService.proto
@@ -34,7 +34,7 @@ message Envelope {
   optional string serverGuid           = 9;
   optional uint64 serverTimestamp      = 10;
   optional bool   urgent               = 14 [default = true];
-  reserved      /*updatedPni*/           15; // Not used presently, may be used in the future
+  optional string updatedPni           = 15; // Used by linked device if primary device changes phone number
   optional bool   story                = 16;
   optional bytes  reporting_token      = 17;
   // NEXT ID: 18


### PR DESCRIPTION
Closes #102. Based on provisioning code from signal-cli:
https://github.com/AsamK/signal-cli/blob/master/lib/src/main/java/org/asamk/signal/manager/ProvisioningManagerImpl.java

Synchronizing contacts, groups and profile did not work in testing. But it also did not work when testing with the official Signal Desktop client, so the source of the problem seems to be elsewhere.

Some parts are a bit hacky, because device linking is stateful (requires keeping an open websocket for the entire process), while the normal registration process is stateless (Separate connection can be made for each step).