### PR TITLE
Remove unsemantic blockquote

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Translation status](https://hosted.weblate.org/widgets/molly-instant-messenger/-/svg-badge.svg)](https://hosted.weblate.org/engage/molly-instant-messenger/?utm_source=widget)
 [![Financial contributors](https://opencollective.com/mollyim/tiers/badge.svg)](https://opencollective.com/mollyim#category-CONTRIBUTE)
 
-> Molly is a hardened version of [Signal](https://github.com/signalapp/Signal-Android) for Android, the fast simple yet secure messaging app by [Signal Foundation](https://signal.org).
+Molly is a hardened version of [Signal](https://github.com/signalapp/Signal-Android) for Android, the fast simple yet secure messaging app by [Signal Foundation](https://signal.org).
 
 ## Introduction
 


### PR DESCRIPTION
> A block quote marker, optionally preceded by up to three spaces of
> indentation, consists of (a) the character `>` together with a
> following space of indentation, or (b) a single character `>` not
> followed by a space of indentation.

— CommonMark Spec v0.30, https://spec.commonmark.org/0.30/#block-quotes

`>` denotes a `<blockquote>` in Markdown and is rendered as such.

> The blockquote element represents a section that is quoted from
> another source.

— W3C HTML spec, https://html.spec.whatwg.org/multipage/grouping-content.html#the-blockquote-element

Since this block in the README isn’t quoting any source, itself or otherwise, the usage of this element is not semantic and should be removed. It’s unclear what value the blockquote is providing.