### PR TITLE
Network security configuration addition

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -90,7 +90,8 @@
                  android:allowBackup="true"
                  android:backupAgent=".absbackup.SignalBackupAgent"
                  android:theme="@style/TextSecure.LightTheme"
-                 android:largeHeap="true">
+                 android:largeHeap="true"
+                 android:networkSecurityConfig="@xml/network_security_config">
 
     <!-- MOLLY: GMS and Google Maps stuff moved to gms/AndroidManifest.xml -->
 

--- a/app/src/main/res/xml/network_security_config.xml
+++ b/app/src/main/res/xml/network_security_config.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config>
+    <base-config cleartextTrafficPermitted="false" />
+</network-security-config>

--- a/build-logic/plugins/src/main/java/android-constants.gradle.kts
+++ b/build-logic/plugins/src/main/java/android-constants.gradle.kts
@@ -2,5 +2,5 @@
 val signalBuildToolsVersion by extra("32.0.0")
 val signalCompileSdkVersion by extra("android-33")
 val signalTargetSdkVersion by extra(31)
-val signalMinSdkVersion by extra(23)
+val signalMinSdkVersion by extra(24)
 val signalJavaVersion by extra(JavaVersion.VERSION_11)


### PR DESCRIPTION
Increment minimum API to 24 and add network security configuration to disable clear text connections for the methods supported by the configuration. This closes a gap between API level 24-28 where clear text connections aren't disabled by default but a network security configuration is supported. For more information see https://developer.android.com/training/articles/security-config#CleartextTrafficPermitted