### PR TITLE
Always use Google maps to share position

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/components/location/SignalPlace.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/components/location/SignalPlace.java
@@ -12,7 +12,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.android.gms.maps.model.LatLng;
 
 import org.signal.core.util.logging.Log;
-import org.thoughtcrime.securesms.BuildConfig;
 import org.thoughtcrime.securesms.maps.AddressData;
 import org.thoughtcrime.securesms.util.JsonUtils;
 
@@ -20,8 +19,7 @@ import java.io.IOException;
 
 public class SignalPlace {
 
-  private static final String GMS_URL = "https://maps.google.com/maps";
-  private static final String OSM_URL = "https://www.openstreetmap.org/";
+  private static final String URL = "https://maps.google.com/maps";
 
   private static final String TAG = Log.tag(SignalPlace.class);
 
@@ -65,17 +63,10 @@ public class SignalPlace {
       description += (address + "\n");
     }
 
-    if (BuildConfig.USE_OSM) {
-      description += Uri.parse(OSM_URL)
-                        .buildUpon()
-                        .encodedFragment(String.format("map=15/%s/%s", latitude, longitude))
-                        .build().toString();
-    } else {
-      description += Uri.parse(GMS_URL)
-                        .buildUpon()
-                        .appendQueryParameter("q", String.format("%s,%s", latitude, longitude))
-                        .build().toString();
-    }
+    description += Uri.parse(URL)
+                      .buildUpon()
+                      .appendQueryParameter("q", String.format("%s,%s", latitude, longitude))
+                      .build().toString();
 
     return description;
   }


### PR DESCRIPTION
Gmaps links are unfortunately like an universal geo: URI, all platforms use these links to open their own GPS app (iOS/Android/Browsers). Even OSM apps on Android use it.

This solution is probably better than #184 since it makes position sharing more usable for everyone.

Another solution would be to have the 2 links (OSM and Gmap) but it is against signal UX, keeping things easy. Then users would have to say 'click on the second link'.