### PR TITLE
Use pushAvailable instead of fcmEnabled when needed

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/components/reminder/DozeReminder.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/components/reminder/DozeReminder.java
@@ -32,7 +32,7 @@ public class DozeReminder extends Reminder {
   }
 
   public static boolean isEligible(Context context) {
-    return !SignalStore.account().isFcmEnabled()                   &&
+    return !SignalStore.account().isPushAvailable()                   &&
            !TextSecurePreferences.hasPromptedOptimizeDoze(context) &&
            !((PowerManager)context.getSystemService(Context.POWER_SERVICE)).isIgnoringBatteryOptimizations(context.getPackageName());
   }

--- a/app/src/main/java/org/thoughtcrime/securesms/dependencies/ApplicationDependencyProvider.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/dependencies/ApplicationDependencyProvider.java
@@ -281,7 +281,7 @@ public class ApplicationDependencyProvider implements ApplicationDependencies.Pr
 
   @Override
   public @NonNull SignalWebSocket provideSignalWebSocket(@NonNull Supplier<SignalServiceConfiguration> signalServiceConfigurationSupplier) {
-    SleepTimer                   sleepTimer      = !SignalStore.account().isFcmEnabled() || SignalStore.internalValues().isWebsocketModeForced() ? new AlarmSleepTimer(context) : new UptimeSleepTimer() ;
+    SleepTimer                   sleepTimer      = !SignalStore.account().isPushAvailable() || SignalStore.internalValues().isWebsocketModeForced() ? new AlarmSleepTimer(context) : new UptimeSleepTimer() ;
     SignalWebSocketHealthMonitor healthMonitor   = new SignalWebSocketHealthMonitor(context, sleepTimer);
     SignalWebSocket              signalWebSocket = new SignalWebSocket(provideWebSocketFactory(signalServiceConfigurationSupplier, healthMonitor));
 


### PR DESCRIPTION
I've kept `val fcmEnabled = SignalStore.account().fcmEnabled` in IncomingMessageObserver for the logs and set `"PushAvailable: $pushAvailable")` in another line to make conflicts easier (there has been lot of changes on that logging line). I've even use another Log.d for unifiedpush flavor.