### PR TITLE
Do not register to distrib from UnifiedPushReceiver

### DIFF
--- a/app/src/main/java/im/molly/unifiedpush/receiver/UnifiedPushReceiver.kt
+++ b/app/src/main/java/im/molly/unifiedpush/receiver/UnifiedPushReceiver.kt
@@ -90,7 +90,7 @@ class UnifiedPushReceiver : MessagingReceiver() {
       message.contains("\"test\":true") -> {
         Log.d(TAG, "Test message received.")
         UnifiedPushNotificationBuilder(context).setNotificationTest()
-        AppDependencies.jobManager.add(UnifiedPushRefreshJob())
+        AppDependencies.jobManager.add(UnifiedPushRefreshJob(testPing = false, fromNewEndpoint = true))
       }
 
       else -> {
@@ -117,7 +117,7 @@ class UnifiedPushReceiver : MessagingReceiver() {
     val stored = SignalStore.unifiedpush.endpoint
     return if (endpoint != stored) {
       SignalStore.unifiedpush.endpoint = endpoint
-      AppDependencies.jobManager.add(UnifiedPushRefreshJob())
+      AppDependencies.jobManager.add(UnifiedPushRefreshJob(testPing = false, fromNewEndpoint = true))
       true
     } else false
   }


### PR DESCRIPTION
To avoid a loop if a distributor changes the endpoint for every new registration request

See https://github.com/mollyim/mollysocket/issues/56