### PR TITLE
opt-in to MTE async mode

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -96,6 +96,7 @@
     <application android:name=".ApplicationContext"
                  android:icon="@mipmap/ic_launcher"
                  android:label="@string/app_name"
+                 android:memtagMode="async"
                  android:supportsRtl="true"
                  android:resizeableActivity="true"
                  android:fullBackupOnly="false"


### PR DESCRIPTION
currently only benefits GrapheneOS users on Pixel 8 and 9 who don't turn on MTE for all apps or Molly manually. hopefully will be extended to all Pixel users and then more devices

[Android Arm Memory Tagging Extension (MTE) documentation](https://developer.android.com/ndk/guides/arm-mte)