### PR TITLE
Filter out Story receivers that can't be reached (Fixes #494)

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/database/SentStorySyncManifest.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/database/SentStorySyncManifest.kt
@@ -42,7 +42,7 @@ data class SentStorySyncManifest(
 
   fun toRecipientsSet(): Set<SignalServiceStoryMessageRecipient> {
     val recipients = Recipient.resolvedList(entries.map { it.recipientId })
-    return recipients.map { recipient ->
+    return recipients.filter { it.hasAci || it.hasPni }.map { recipient ->
       val serviceId = recipient.requireServiceId()
       val entry = entries.first { it.recipientId == recipient.id }
 


### PR DESCRIPTION
This fixes the issue described in #494 which happens if a Story is tried to be sent to an account which has neither an ACI nor a PNI set.

As described in [this comment](https://github.com/mollyim/mollyim-android/issues/494#issuecomment-2848630502) of the issue this happens due to there [not being a guarantee](https://github.com/mollyim/mollyim-android/blob/5a8a33070d9c71d4b17b035c4ac9333ef812040b/app/src/main/java/org/thoughtcrime/securesms/database/RecipientTableCursorUtil.kt#L122-L123) that an account has either an ACI or PNI when querying them but the `toRecipientSet` function [assuming](https://github.com/mollyim/mollyim-android/blob/b8ddb9e6735b372dc0a406f8ddf5537c755ce7ec/app/src/main/java/org/thoughtcrime/securesms/database/SentStorySyncManifest.kt#L46) that they are in place leading to a crash when that is not the case.

This change filters the recipients to only include valid ones.

---

A thought about why this might only be an issue with Stories (as I had no issues before trying to create a story): My assumption is that at least one of my contacts is missing this data, maybe even because the account was deleted or outdated (or simply corrupted in memory/on import?). Seeing as only Stories send to all users compared to messages or groups that only go to a certain one this error got triggered in an unexpected way. (I will try to analyse which user that is further but my contact list isn't exactly small)

Also one might question if this is really a valid fix for this issue even though it does not resolve the underlying issue of potentially invalid contacts existing: Imo. it is due to the "spec" of the `Recipient.resolvedList` not guaranteeing that this particular information is actually available on the Recipient hence why this filter should've been done here in the first place anyways. (And of course not lead to an app crash)