### PR TITLE
Update fConfig fronting domains for censorship circumvention

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/push/SignalServiceNetworkAccess.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/push/SignalServiceNetworkAccess.kt
@@ -74,8 +74,6 @@ class SignalServiceNetworkAccess(context: Context) {
     private const val HTTPS_CLIENTS_4_GOOGLE_COM = "https://clients4.google.com"
     private const val HTTPS_GOOGLEMAIL_COM = "https://googlemail.com"
     private const val HTTPS_GITHUB_GITHUBASSETS_COM = "https://github.githubassets.com"
-    private const val HTTPS_PINTEREST_COM = "https://pinterest.com"
-    private const val HTTPS_WWW_REDDITSTATIC_COM = "https://www.redditstatic.com"
     private const val HTTPS_WWW_GOOGLE_COM_EG = "https://www.google.com.eg"
     private const val HTTPS_WWW_GOOGLE_AE = "https://www.google.ae"
     private const val HTTPS_WWW_GOOGLE_COM_OM = "https://www.google.com.om"
@@ -83,6 +81,7 @@ class SignalServiceNetworkAccess(context: Context) {
     private const val HTTPS_WWW_GOOGLE_CO_UZ = "https://www.google.co.uz"
     private const val HTTPS_WWW_GOOGLE_CO_VE = "https://www.google.co.ve"
     private const val HTTPS_WWW_GOOGLE_COM_PK = "https://www.google.com.pk"
+    private const val HTTPS_WWW_GOV_UK = "https://www.gov.uk"
 
     @JvmField
     val HOSTNAMES = setOf(
@@ -113,8 +112,6 @@ class SignalServiceNetworkAccess(context: Context) {
       HTTPS_CLIENTS_4_GOOGLE_COM.stripProtocol(),
       HTTPS_GOOGLEMAIL_COM.stripProtocol(),
       HTTPS_GITHUB_GITHUBASSETS_COM.stripProtocol(),
-      HTTPS_PINTEREST_COM.stripProtocol(),
-      HTTPS_WWW_REDDITSTATIC_COM.stripProtocol(),
       HTTPS_WWW_GOOGLE_COM_EG.stripProtocol(),
       HTTPS_WWW_GOOGLE_AE.stripProtocol(),
       HTTPS_WWW_GOOGLE_COM_OM.stripProtocol(),
@@ -122,6 +119,7 @@ class SignalServiceNetworkAccess(context: Context) {
       HTTPS_WWW_GOOGLE_CO_UZ.stripProtocol(),
       HTTPS_WWW_GOOGLE_CO_VE.stripProtocol(),
       HTTPS_WWW_GOOGLE_COM_PK.stripProtocol(),
+      HTTPS_WWW_GOV_UK.stripProtocol(),
     )
 
     private val GMAPS_CONNECTION_SPEC = ConnectionSpec.Builder(ConnectionSpec.MODERN_TLS)
@@ -240,7 +238,7 @@ class SignalServiceNetworkAccess(context: Context) {
     HostConfig(HTTPS_GOOGLEMAIL_COM, G_HOST, GMAIL_CONNECTION_SPEC)
   )
 
-  private val fUrls = arrayOf(HTTPS_GITHUB_GITHUBASSETS_COM, HTTPS_PINTEREST_COM, HTTPS_WWW_REDDITSTATIC_COM)
+  private val fUrls = arrayOf(HTTPS_GITHUB_GITHUBASSETS_COM, HTTPS_WWW_GOV_UK)
 
   private val fConfig: SignalServiceConfiguration = SignalServiceConfiguration(
     signalServiceUrls = fUrls.map { SignalServiceUrl(it, F_SERVICE_HOST, fTrustStore, APP_CONNECTION_SPEC) }.toTypedArray(),

--- a/app/src/main/java/org/thoughtcrime/securesms/push/SignalServiceNetworkAccess.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/push/SignalServiceNetworkAccess.kt
@@ -51,6 +51,7 @@ class SignalServiceNetworkAccess(context: Context) {
     private const val COUNTRY_CODE_OMAN = 968
     private const val COUNTRY_CODE_QATAR = 974
     private const val COUNTRY_CODE_IRAN = 98
+    private const val COUNTRY_CODE_CHINA = 86
     private const val COUNTRY_CODE_CUBA = 53
     private const val COUNTRY_CODE_UZBEKISTAN = 998
     private const val COUNTRY_CODE_VENEZUELA = 58
@@ -285,6 +286,7 @@ class SignalServiceNetworkAccess(context: Context) {
       listOf(HostConfig(HTTPS_WWW_GOOGLE_COM_PK, G_HOST, GMAIL_CONNECTION_SPEC)) + baseGHostConfigs
     ),
     COUNTRY_CODE_IRAN to fConfig,
+    COUNTRY_CODE_CHINA to fConfig,
     COUNTRY_CODE_CUBA to fConfig
   )
 
@@ -296,6 +298,7 @@ class SignalServiceNetworkAccess(context: Context) {
     COUNTRY_CODE_OMAN,
     COUNTRY_CODE_QATAR,
     COUNTRY_CODE_IRAN,
+    COUNTRY_CODE_CHINA,
     COUNTRY_CODE_CUBA,
     COUNTRY_CODE_UZBEKISTAN,
     COUNTRY_CODE_VENEZUELA,


### PR DESCRIPTION
Initial pull request:

* https://github.com/signalapp/Signal-Android/pull/13681

Former request:

* https://github.com/mollyim/mollyim-android/issues/391

I still think that the domains of social networking sites are more likely to be blocked and should be replaced to something more solid.

This patch replaced the Reddit and Pinterest domains with `www.gov.uk`, which also uses Fastly CDN, as they [stated on their website](https://docs.publishing.service.gov.uk/manual/cdn.html) and [confirmed](https://dnschecker.org/#A/www.gov.uk). The censors of Iran, Cuba, and China will face heavy collateral damage blocking it.

My former pull request to Signal also included `www.python.org`, this programming language is popular in China, and it might also be in Iran. Cuba is unknown.

* https://www.iranintl.com/en/202304146827 "‘Python-Gate’: Raisi Administration’s New Embarrassment"

