### PR TITLE
Disable Google Safe Browsing in WebViews

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -132,6 +132,7 @@
     <meta-data android:name="google_analytics_adid_collection_enabled" android:value="false" />
     <meta-data android:name="firebase_messaging_auto_init_enabled" android:value="false" />
     <meta-data android:name="android.webkit.WebView.MetricsOptOut" android:value="true" />
+    <meta-data android:name="android.webkit.WebView.EnableSafeBrowsing" android:value="false" />
 
     <activity android:name=".components.webrtc.v2.WebRtcCallActivity"
               android:theme="@style/TextSecure.DarkTheme.WebRTCCall"


### PR DESCRIPTION
There's little to no security benefit from enabling Google Safe Browsing, because the only URLs that are loaded in the app's WebViews are from payment processors and captchas. Safe Browsing requires sending data about the URLs visited within the WebView to Google, and so disabling Safe Browsing might be helpful for users who don't want Google to know that they use Signal. 

Of course, there's no evidence that Google is actually using Safe Browsing to track people, but Google can't be trusted in general.