### PR TITLE
Implemented quick reaction on incoming messages

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/ConversationAdapterV2.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/ConversationAdapterV2.kt
@@ -393,6 +393,7 @@ class ConversationAdapterV2(
   private inner class IncomingMediaViewHolder(itemView: View) : ConversationViewHolder<IncomingMedia>(itemView) {
     override fun bind(model: IncomingMedia) {
       bindable.setEventListener(clickListener)
+      bindable.setGestureDetector(gestureDetector)
 
       if (bindPayloadsIfAvailable()) {
         return

--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/ConversationFragment.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/ConversationFragment.kt
@@ -3345,7 +3345,35 @@ class ConversationFragment :
 
     override fun onItemDoubleClick(item: MultiselectPart) {
       Log.d(TAG, "onItemDoubleClick")
+
+      // Quick reaction works only on incoming messages
+      if (!item.conversationMessage.messageRecord.isOutgoing) {
+        onDoubleTapToQuickReact(item.conversationMessage)
+      }
       onDoubleTapToEdit(item.conversationMessage)
+    }
+
+    private fun onDoubleTapToQuickReact(conversationMessage: ConversationMessage) {
+      if (isActionModeStarted()) {
+        return
+      }
+
+      val messageRecord = conversationMessage.getMessageRecord()
+      if (messageRecord.isInMemoryMessageRecord || messageRecord.isOutgoing || !messageRecord.isValidReactionTarget()) {
+        return
+      }
+
+      val recipient = viewModel.recipientSnapshot ?: return
+      if (recipient.isBlocked || viewModel.hasMessageRequestState || (recipient.isGroup && !recipient.isActiveGroup)) {
+        return
+      }
+
+      if (adapter.selectedItems.isNotEmpty()) {
+        return
+      }
+
+      val emoji = SignalStore.emoji.reactions.first()
+      disposables += viewModel.updateReaction(messageRecord, emoji).subscribe()
     }
 
     private fun onDoubleTapToEdit(conversationMessage: ConversationMessage) {

--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/ConversationFragment.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/ConversationFragment.kt
@@ -3346,11 +3346,11 @@ class ConversationFragment :
     override fun onItemDoubleClick(item: MultiselectPart) {
       Log.d(TAG, "onItemDoubleClick")
 
-      // Quick reaction works only on incoming messages
-      if (!item.conversationMessage.messageRecord.isOutgoing) {
+      if (item.conversationMessage.messageRecord.isOutgoing) {
+        onDoubleTapToEdit(item.conversationMessage)
+      } else {
         onDoubleTapToQuickReact(item.conversationMessage)
       }
-      onDoubleTapToEdit(item.conversationMessage)
     }
 
     private fun onDoubleTapToQuickReact(conversationMessage: ConversationMessage) {


### PR DESCRIPTION
Implemented a telegram-like quick reaction on incoming messages when double tapping.

**Quick reaction works only on incoming messages, so that "tap to edit" method stays as is for outgoing ones.**

The emoji for quick reaction is the first one from user's chosen list.