### PR TITLE
fix: add DataRestoreConstraint to StorageSyncJob

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/jobs/StorageSyncJob.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/jobs/StorageSyncJob.kt
@@ -15,6 +15,7 @@ import org.thoughtcrime.securesms.database.RecipientTable
 import org.thoughtcrime.securesms.database.SignalDatabase
 import org.thoughtcrime.securesms.dependencies.AppDependencies
 import org.thoughtcrime.securesms.jobmanager.Job
+import org.thoughtcrime.securesms.jobmanager.impl.DataRestoreConstraint
 import org.thoughtcrime.securesms.jobmanager.impl.NetworkConstraint
 import org.thoughtcrime.securesms.jobs.protos.StorageSyncJobData
 import org.thoughtcrime.securesms.keyvalue.SignalStore
@@ -159,6 +160,7 @@ class StorageSyncJob private constructor(parameters: Parameters, private var loc
   private constructor(localManifestOutOfDate: Boolean, @Parameters.Priority priority: Int = Parameters.PRIORITY_DEFAULT) : this(
     Parameters.Builder()
       .addConstraint(NetworkConstraint.KEY)
+      .addConstraint(DataRestoreConstraint.KEY)
       .setGlobalPriority(priority)
       .setQueue(QUEUE_KEY)
       .setMaxInstancesForFactory(2)


### PR DESCRIPTION
## Summary

- Add `DataRestoreConstraint` to `StorageSyncJob` to prevent it from running during local backup restore

## Problem

During local backup restore, `StorageSyncJob` can execute before the restore completes, attempting to sync with Signal's storage service while the database is still being populated. This causes the restore to fail or hang indefinitely.

## Fix

Add `.addConstraint(DataRestoreConstraint.KEY)` to `StorageSyncJob`'s `Parameters.Builder`. This follows the same pattern already used by `RebuildMessageSearchIndexJob`, which correctly blocks during restore.

When `DataRestoreConstraint.isRestoringData` is `true` (set by `RestoreRepository` at the start of restore), the constraint prevents `StorageSyncJob` from executing. Once restore completes and the flag is cleared, the job proceeds normally.

## Changes

- `StorageSyncJob.kt`: Added `DataRestoreConstraint.KEY` constraint and its import (2 lines)

## Test plan

- [ ] Perform a local backup restore — verify StorageSyncJob does not run until restore completes
- [ ] Verify normal storage sync still works after app restart (constraint is not active outside restore)
- [ ] Verify no regression in cloud backup restore flow

Fixes #733