### PR TITLE
fix(captcha): fall back to external browser when system WebView is disabled (refs #303)

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/registration/ui/captcha/CaptchaFragment.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/registration/ui/captcha/CaptchaFragment.kt
@@ -6,6 +6,9 @@
 package org.thoughtcrime.securesms.registration.ui.captcha
 
 import android.annotation.SuppressLint
+import android.content.ActivityNotFoundException
+import android.content.Intent
+import android.net.Uri
 import android.os.Bundle
 import android.view.View
 import android.webkit.WebView
@@ -25,22 +28,55 @@ abstract class CaptchaFragment : LoggingFragment(R.layout.fragment_registration_
   @SuppressLint("SetJavaScriptEnabled")
   override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
     super.onViewCreated(view, savedInstanceState)
-    binding.registrationCaptchaWebView.settings.javaScriptEnabled = true
-    binding.registrationCaptchaWebView.clearCache(true)
 
-    binding.registrationCaptchaWebView.webViewClient = object : WebViewClient() {
-      @Deprecated("Deprecated in Java")
-      override fun shouldOverrideUrlLoading(view: WebView, url: String): Boolean {
-        if (url.startsWith(RegistrationConstants.SIGNAL_CAPTCHA_SCHEME)) {
-          val token = url.substring(RegistrationConstants.SIGNAL_CAPTCHA_SCHEME.length)
-          handleCaptchaToken(token)
-          findNavController().navigateUp()
-          return true
-        }
-        return false
-      }
+    // Issue #303: users that have disabled / removed the system WebView
+    // (low-storage devices, hardened ROMs) cannot complete the captcha
+    // because the WebView either fails to inflate or refuses to load.
+    // Detect that case and fall back to opening the captcha URL in the
+    // user's default browser — the `signalcaptcha://` URI scheme handler
+    // brings them back into the app with the token via the existing
+    // intent filter.
+    val webView = try {
+      binding.registrationCaptchaWebView
+    } catch (e: Throwable) {
+      openCaptchaInBrowser()
+      return
     }
-    binding.registrationCaptchaWebView.loadUrl(BuildConfig.SIGNAL_CAPTCHA_URL)
+
+    try {
+      webView.settings.javaScriptEnabled = true
+      webView.clearCache(true)
+
+      webView.webViewClient = object : WebViewClient() {
+        @Deprecated("Deprecated in Java")
+        override fun shouldOverrideUrlLoading(view: WebView, url: String): Boolean {
+          if (url.startsWith(RegistrationConstants.SIGNAL_CAPTCHA_SCHEME)) {
+            val token = url.substring(RegistrationConstants.SIGNAL_CAPTCHA_SCHEME.length)
+            handleCaptchaToken(token)
+            findNavController().navigateUp()
+            return true
+          }
+          return false
+        }
+      }
+      webView.loadUrl(BuildConfig.SIGNAL_CAPTCHA_URL)
+    } catch (e: Throwable) {
+      // Catches AndroidRuntimeException("WebView ... not available") thrown
+      // by the WebView constructor / settings when the WebView package is
+      // disabled at runtime.
+      openCaptchaInBrowser()
+    }
+  }
+
+  private fun openCaptchaInBrowser() {
+    val intent = Intent(Intent.ACTION_VIEW, Uri.parse(BuildConfig.SIGNAL_CAPTCHA_URL))
+    intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+    try {
+      startActivity(intent)
+    } catch (e: ActivityNotFoundException) {
+      // No browser available; let the user back out.
+    }
+    findNavController().navigateUp()
   }
 
   abstract fun handleCaptchaToken(token: String)


### PR DESCRIPTION
## Open captcha in the default browser when WebView is disabled (refs #303)

### Problem

Issue #303 reports that disabling / removing the system
WebView (a common configuration on low-storage devices and
some hardened ROMs) bricks registration: `CaptchaFragment`
unconditionally calls into the WebView and either silently
fails to render or crashes when the WebView constructor
throws `AndroidRuntimeException("WebView ... not available")`.

### Fix

Wrap the WebView access in a try/catch. If accessing the
WebView (`binding.registrationCaptchaWebView` and its
`settings`) throws, or if `loadUrl` throws, fall back to
launching `BuildConfig.SIGNAL_CAPTCHA_URL` via
`Intent.ACTION_VIEW`. The existing `signalcaptcha://` URI
scheme handler (the same one the share-sheet uses today)
brings the user back into the app with the token and
`handleCaptchaToken` runs as normal.

If no browser is available either we just `navigateUp()` so
the user can back out and retry, no worse than the current
blank-screen behaviour.

### Why this is in scope of `mollyim-android`

Upstream Signal does not have to care because it does not
ship a browser-light user base. The mollyim user base has
explicitly asked for it (#303) and the change is
self-contained inside the fork's existing CaptchaFragment
(no AndroidManifest or shared-component edits).

### Notes

* The intent filter for `signalcaptcha://` is already
  declared (it is what makes the share-sheet workflow
  function today), so the round-trip through the browser
  works without any manifest changes.
* `clearCache(true)` is preserved on the WebView path; the
  browser path does not need it because the user's browser
  manages its own cache.
