### PR TITLE
Fix failure loop when sending messages after push method update

### DIFF
--- a/app/src/main/java/im/molly/unifiedpush/MollySocketRepository.kt
+++ b/app/src/main/java/im/molly/unifiedpush/MollySocketRepository.kt
@@ -94,7 +94,7 @@ object MollySocketRepository {
 
   @Throws(IOException::class)
   fun removeDevice(device: MollySocketDevice) {
-    AppDependencies.linkDeviceApi.removeDevice(device.deviceId).successOrThrow()
+    LinkDeviceRepository.removeDevice(device.deviceId)
   }
 
   fun getDeviceStatus(device: MollySocketDevice): LinkStatus {

--- a/app/src/main/java/im/molly/unifiedpush/MollySocketRepository.kt
+++ b/app/src/main/java/im/molly/unifiedpush/MollySocketRepository.kt
@@ -15,17 +15,25 @@ import okhttp3.RequestBody.Companion.toRequestBody
 import org.signal.core.util.Base64
 import org.signal.core.util.Util
 import org.signal.core.util.logging.Log
+import org.signal.libsignal.protocol.SessionBuilder
+import org.signal.libsignal.protocol.SignalProtocolAddress
 import org.signal.libsignal.protocol.util.KeyHelper
 import org.thoughtcrime.securesms.AppCapabilities
+import org.thoughtcrime.securesms.crypto.ReentrantSessionLock
 import org.thoughtcrime.securesms.dependencies.AppDependencies
+import org.thoughtcrime.securesms.dependencies.AppDependencies.keysApi
 import org.thoughtcrime.securesms.keyvalue.PhoneNumberPrivacyValues.PhoneNumberDiscoverabilityMode
 import org.thoughtcrime.securesms.keyvalue.SignalStore
 import org.thoughtcrime.securesms.linkdevice.LinkDeviceRepository
 import org.thoughtcrime.securesms.push.AccountManagerFactory
+import org.thoughtcrime.securesms.recipients.Recipient
 import org.thoughtcrime.securesms.registration.data.RegistrationRepository
 import org.thoughtcrime.securesms.registration.secondary.DeviceNameCipher
 import org.thoughtcrime.securesms.util.JsonUtils
+import org.whispersystems.signalservice.api.NetworkResultUtil
 import org.whispersystems.signalservice.api.account.AccountAttributes
+import org.whispersystems.signalservice.api.crypto.SignalSessionBuilder
+import org.whispersystems.signalservice.api.push.SignalServiceAddress
 import org.whispersystems.signalservice.internal.push.DeviceLimitExceededException
 import java.io.IOException
 import java.net.MalformedURLException
@@ -87,9 +95,32 @@ object MollySocketRepository {
       accountAttributes,
       aciPreKeyCollection, pniPreKeyCollection,
       null
-    ).also {
+    ).also { deviceId ->
       SignalStore.account.isMultiDevice = true
+      loadPreKeys(deviceId)
     }
+  }
+
+  /**
+   * We need to load prekeys, else we get a bug if MollySocket is the only linked device:
+   * - SignalStore.account.isMultiDevice is set to `true` => we try to [sendSyncMessage][org.whispersystems.signalservice.api.SignalServiceMessageSender.sendSyncMessage]
+   * - [SignalServiceAccountDataStore.containsSession] returns false for this device
+   * - So, [getEncryptedMessage][org.whispersystems.signalservice.api.SignalServiceMessageSender.getEncryptedMessage] removes this device => it returns a OutgoingPushMessageList with an empty message list
+   * - [sendMessage][org.whispersystems.signalservice.api.SignalServiceMessageSender.sendMessage] fails with NonSuccessfulResponseCodeException: [400],
+   *     we don't get the Mismatched device exception [409] which allow handling ExtraDevices/MissingDevices.
+   * - We're stuck in a loop where we can't send a message.
+   */
+  private fun loadPreKeys(deviceId: Int) {
+    val recipient = SignalServiceAddress(Recipient.self().requireAci())
+    val preKey = NetworkResultUtil.toPreKeysLegacy(keysApi.getPreKey(recipient, deviceId));
+    val sessionBuilder = SignalSessionBuilder(
+      ReentrantSessionLock.INSTANCE,
+      SessionBuilder(
+        AppDependencies.protocolStore.aci(),
+        SignalProtocolAddress(recipient.identifier, deviceId)
+      )
+    )
+    sessionBuilder.process(preKey)
   }
 
   @Throws(IOException::class)


### PR DESCRIPTION
Fix #732

There were actually 2 bugs:
- When deleting the linked device, we didn't update isMultiDevice, which led to sending sync requests to an empty list of devices, causing an error loop
- When linking to a new MollySocker linked device, we didn't add any pre-keys, which led to this device being [filter out, as an inactive device](https://github.com/mollyim/mollyim-android/blob/914315b220916b50cecd1ecf1a8daaeaf0a9e357/lib/libsignal-service/src/main/java/org/whispersystems/signalservice/api/SignalServiceMessageSender.java#L2830), causing sending sync requests to an empty list of devices, causing the same error loop

I don't know exactly why we didn't have that bug earlier, I suppose this is a new mechanism to filter out messages to stalled devices

Additionally, something should be done to prevent sending to an empty list of devices (this can happen only when sending messages to ourselves), causing this error 400. We can either:
1. When the [deviceIds](https://github.com/mollyim/mollyim-android/blob/914315b220916b50cecd1ecf1a8daaeaf0a9e357/lib/libsignal-service/src/main/java/org/whispersystems/signalservice/api/SignalServiceMessageSender.java#L2830) after filter is empty, we add a dummy deviceId `2` => so we can get a 409, and Extra/Missing devices will be returned by the server
2. Or return without processing the different `sendMessage` function when `OutgoingPushMessage.messages` is empty
3. Update SignalServer to return a 409 instead of 400 when `messages` is empty

I think the cleaner would be the 3rd option, but we don't have the hand on it. Then, even if it sounds more hacky, I'd go with the first solution, so any new function relying on getEncryptedMessage wouldn't reintroduce the bug.