### PR TITLE
feat(kids flavor): opt-in parental controls for family Signal use

### DIFF
--- a/README-MOLLYKIDS.md
+++ b/README-MOLLYKIDS.md
@@ -1,0 +1,116 @@
+# MollyKids
+
+**MollyKids** is a downstream fork of [Molly](https://github.com/mollyim/mollyim-android) — a
+security-hardened Signal client — that adds parental controls for family use. It lets children
+communicate with pre-approved family members via Signal-compatible messaging on semi-locked-down
+tablets, while keeping parents in full control of who the child can reach.
+
+---
+
+## Why MollyKids?
+
+Signal is excellent for secure family communication, but it has no concept of a restricted
+child account. MollyKids adds a PIN-gated parental layer that:
+
+- Shows children **only the group chats parents explicitly allow** — no contacts list, no new
+  conversations
+- **Blocks outbound messaging** to any thread not on the allow-list
+- **Suppresses notifications** from non-allowed threads so nothing leaks through
+- **Hides Stories, account settings, and linked-device management** from the child
+- Lets parents manage the allow-list and change the PIN via a PIN-gated Settings panel on the
+  device itself
+
+Registration uses **free Google Voice numbers** (one per child) so children never expose their
+own phone numbers. After setup, communication happens via Signal usernames — no numbers visible
+to the child at all.
+
+---
+
+## How It Works (Architecture)
+
+All parental-control code lives behind a **`kids` Gradle build flavor**. The standard `prod`
+and `staging` flavors are completely unaffected — zero changes to shared Signal protocol,
+crypto, database, or network code.
+
+Key additions:
+
+| File / Package | What it does |
+|---|---|
+| `app/src/kids/` | Flavor-specific overrides |
+| `app/src/main/.../keyvalue/ParentalControlValues.kt` | PIN storage (SHA-256 + random salt) and allowed-thread list |
+| `app/src/main/.../parental/` | Parent Settings UI — Activity, ViewModel, Fragments, PIN dialogs |
+| Guard clauses in `ConversationListFragment`, `MainActivity`, `NotificationController`, etc. | `if (SignalStore.parental().parentalModeEnabled)` checks that activate restrictions |
+
+The `kids` flavor is **opt-in at build time**. A family builds the `kidsRelease` APK; a privacy
+researcher builds the standard `prodRelease` APK. Both come from the same source tree.
+
+---
+
+## Build Instructions
+
+**Prerequisites:** Android Studio, JDK 17+, standard Molly build dependencies
+(see [Molly's README](README.md)).
+
+```bash
+# Build the kids flavor APK
+./gradlew assembleKidsRelease
+
+# Run parental-control unit tests
+./gradlew testKidsDebugUnitTest
+```
+
+The kids flavor APK can be sideloaded onto a child's device. After installation, parents
+enable Parental Mode from within the app using the PIN-gated Parent Settings screen.
+
+---
+
+## Implementation Status
+
+| Phase | Feature | Status |
+|---|---|---|
+| 0 | Kids Gradle flavor scaffolding | Done |
+| 1 | `ParentalControlValues` — PIN + allow-list storage | Done |
+| 2 | Conversation list filtering | Done |
+| 3 | Block new outbound conversations | Done |
+| 4 | Gate group invites behind PIN | Done |
+| 5 | Suppress notifications for non-allowed threads | Done |
+| 6 | Hide Stories tab and lock account settings | Done |
+| 7 | Parent Settings UI (PIN-gated panel on device) | Done |
+| 8 | Registration guide and first-run setup flow | Not started |
+
+62 unit tests cover the parental control layer; all pass on the current build.
+
+---
+
+## Upstream Compatibility
+
+MollyKids tracks upstream Molly releases. The parental-controls branch is kept rebased/merged
+against Molly's main; the most recent sync was **Molly v8.7.3-2** (2026-04-29) with zero merge
+conflicts.
+
+When Molly releases a new version, the merge process is:
+
+```bash
+git fetch upstream
+git merge upstream/main   # or the relevant release tag
+# Resolve any conflicts (historically: none in parental files)
+```
+
+---
+
+## License
+
+AGPLv3, same as Molly and Signal. If you distribute this app (outside your own household),
+the source must remain publicly available — which it is, right here.
+
+---
+
+## Relationship to Molly
+
+MollyKids is a **downstream consumer** of Molly, not a competing project. Molly's security
+hardening (encrypted database, app lock, no Google tracking) is exactly why it's a good
+foundation for a children's device. We rely on Molly's security properties and contribute
+nothing back that changes them.
+
+If the Molly project ever wants to include parental controls as an opt-in build flavor,
+we're happy to discuss upstreaming this work.

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -31,8 +31,12 @@ val selectableVariants = listOf(
   "prodStoreDebug",
   "prodStoreRelease",
   "prodWebsiteInstrumentation",
+  "prodKidsDebug",
+  "prodKidsRelease",
   "stagingWebsiteDebug",
   "stagingWebsiteRelease",
+  "stagingKidsDebug",
+  "stagingKidsRelease",
 )
 
 // Override build config via env vars when project property 'CI' is set
@@ -292,6 +296,13 @@ android {
       dimension = "distribution"
       buildConfigField("boolean", "MANAGE_MOLLY_UPDATES", "true")
       isDefault = true
+    }
+
+    create("kids") {
+      dimension = "distribution"
+      buildConfigField("boolean", "MANAGE_MOLLY_UPDATES", "true")
+      applicationIdSuffix = ".kids"
+      buildConfigField("boolean", "PARENTAL_CONTROLS_ENABLED", "true")
     }
 
     create("prod") {

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -301,7 +301,6 @@ android {
     create("kids") {
       dimension = "distribution"
       buildConfigField("boolean", "MANAGE_MOLLY_UPDATES", "true")
-      applicationIdSuffix = ".kids"
       buildConfigField("boolean", "PARENTAL_CONTROLS_ENABLED", "true")
     }
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -32,8 +32,12 @@ val selectableVariants = listOf(
   "prodStoreDebug",
   "prodStoreRelease",
   "prodWebsiteInstrumentation",
+  "prodKidsDebug",
+  "prodKidsRelease",
   "stagingWebsiteDebug",
   "stagingWebsiteRelease",
+  "stagingKidsDebug",
+  "stagingKidsRelease",
 )
 
 // Override build config via env vars when project property 'CI' is set
@@ -279,6 +283,13 @@ android {
       dimension = "distribution"
       buildConfigField("boolean", "MANAGE_MOLLY_UPDATES", "true")
       isDefault = true
+    }
+
+    create("kids") {
+      dimension = "distribution"
+      buildConfigField("boolean", "MANAGE_MOLLY_UPDATES", "true")
+      applicationIdSuffix = ".kids"
+      buildConfigField("boolean", "PARENTAL_CONTROLS_ENABLED", "true")
     }
 
     create("prod") {

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -288,7 +288,6 @@ android {
     create("kids") {
       dimension = "distribution"
       buildConfigField("boolean", "MANAGE_MOLLY_UPDATES", "true")
-      applicationIdSuffix = ".kids"
       buildConfigField("boolean", "PARENTAL_CONTROLS_ENABLED", "true")
     }
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -504,6 +504,13 @@
         </activity>
 
         <activity
+            android:name=".parental.ParentalControlActivity"
+            android:configChanges="touchscreen|keyboard|keyboardHidden|orientation|screenLayout|screenSize"
+            android:exported="false"
+            android:theme="@style/Theme.Signal.DayNight.NoActionBar"
+            android:windowSoftInputMode="adjustResize" />
+
+        <activity
             android:name=".stories.my.MyStoriesActivity"
             android:configChanges="touchscreen|keyboard|keyboardHidden|orientation|screenLayout|screenSize"
             android:exported="false"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -498,6 +498,13 @@
         </activity>
 
         <activity
+            android:name=".parental.ParentalControlActivity"
+            android:configChanges="touchscreen|keyboard|keyboardHidden|orientation|screenLayout|screenSize"
+            android:exported="false"
+            android:theme="@style/Theme.Signal.DayNight.NoActionBar"
+            android:windowSoftInputMode="adjustResize" />
+
+        <activity
             android:name=".stories.my.MyStoriesActivity"
             android:configChanges="touchscreen|keyboard|keyboardHidden|orientation|screenLayout|screenSize"
             android:exported="false"

--- a/app/src/main/java/org/thoughtcrime/securesms/MainActivity.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/MainActivity.kt
@@ -150,6 +150,8 @@ import org.thoughtcrime.securesms.main.MainToolbarViewModel
 import org.thoughtcrime.securesms.main.Material3OnScrollHelperBinder
 import org.thoughtcrime.securesms.main.callNavGraphBuilder
 import org.thoughtcrime.securesms.main.chatNavGraphBuilder
+import org.thoughtcrime.securesms.parental.ParentalPinDialog
+import org.thoughtcrime.securesms.parental.PendingGroupInvitesFragment
 import org.thoughtcrime.securesms.main.navigateToDetailLocation
 import org.thoughtcrime.securesms.main.rememberDetailNavHostController
 import org.thoughtcrime.securesms.main.rememberFocusRequester
@@ -1203,6 +1205,12 @@ class MainActivity :
     override fun onNotificationProfileTooltipDismissed() {
       SignalStore.notificationProfile.hasSeenTooltip = true
       toolbarViewModel.setShowNotificationProfilesTooltip(false)
+    }
+
+    override fun onPendingGroupInvitesClick() {
+      ParentalPinDialog.show(this@MainActivity) {
+        PendingGroupInvitesFragment.show(supportFragmentManager)
+      }
     }
   }
 

--- a/app/src/main/java/org/thoughtcrime/securesms/MainActivity.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/MainActivity.kt
@@ -150,6 +150,7 @@ import org.thoughtcrime.securesms.main.MainToolbarViewModel
 import org.thoughtcrime.securesms.main.Material3OnScrollHelperBinder
 import org.thoughtcrime.securesms.main.callNavGraphBuilder
 import org.thoughtcrime.securesms.main.chatNavGraphBuilder
+import org.thoughtcrime.securesms.parental.ParentalControlActivity
 import org.thoughtcrime.securesms.parental.ParentalPinDialog
 import org.thoughtcrime.securesms.parental.PendingGroupInvitesFragment
 import org.thoughtcrime.securesms.main.navigateToDetailLocation
@@ -1210,6 +1211,20 @@ class MainActivity :
     override fun onPendingGroupInvitesClick() {
       ParentalPinDialog.show(this@MainActivity) {
         PendingGroupInvitesFragment.show(supportFragmentManager)
+      }
+    }
+
+    override fun onParentalControlsClick() {
+      val pc = SignalStore.parentalControl
+      if (pc.parentPinHash.isEmpty()) {
+        startActivity(
+          Intent(this@MainActivity, ParentalControlActivity::class.java)
+            .putExtra(ParentalControlActivity.EXTRA_SETUP_PIN, true)
+        )
+      } else {
+        ParentalPinDialog.show(this@MainActivity) {
+          startActivity(Intent(this@MainActivity, ParentalControlActivity::class.java))
+        }
       }
     }
   }

--- a/app/src/main/java/org/thoughtcrime/securesms/MainActivity.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/MainActivity.kt
@@ -155,6 +155,8 @@ import org.thoughtcrime.securesms.main.MainToolbarMode
 import org.thoughtcrime.securesms.main.MainToolbarState
 import org.thoughtcrime.securesms.main.MainToolbarViewModel
 import org.thoughtcrime.securesms.main.Material3OnScrollHelperBinder
+import org.thoughtcrime.securesms.parental.ParentalPinDialog
+import org.thoughtcrime.securesms.parental.PendingGroupInvitesFragment
 import org.thoughtcrime.securesms.mediasend.v2.MediaSelectionActivity
 import org.thoughtcrime.securesms.mediasend.v3.mediaSendLauncher
 import org.thoughtcrime.securesms.megaphone.Megaphone
@@ -1204,6 +1206,12 @@ class MainActivity :
     override fun onNotificationProfileTooltipDismissed() {
       SignalStore.notificationProfile.hasSeenTooltip = true
       toolbarViewModel.setShowNotificationProfilesTooltip(false)
+    }
+
+    override fun onPendingGroupInvitesClick() {
+      ParentalPinDialog.show(this@MainActivity) {
+        PendingGroupInvitesFragment.show(supportFragmentManager)
+      }
     }
   }
 

--- a/app/src/main/java/org/thoughtcrime/securesms/MainActivity.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/MainActivity.kt
@@ -155,6 +155,7 @@ import org.thoughtcrime.securesms.main.MainToolbarMode
 import org.thoughtcrime.securesms.main.MainToolbarState
 import org.thoughtcrime.securesms.main.MainToolbarViewModel
 import org.thoughtcrime.securesms.main.Material3OnScrollHelperBinder
+import org.thoughtcrime.securesms.parental.ParentalControlActivity
 import org.thoughtcrime.securesms.parental.ParentalPinDialog
 import org.thoughtcrime.securesms.parental.PendingGroupInvitesFragment
 import org.thoughtcrime.securesms.mediasend.v2.MediaSelectionActivity
@@ -1211,6 +1212,20 @@ class MainActivity :
     override fun onPendingGroupInvitesClick() {
       ParentalPinDialog.show(this@MainActivity) {
         PendingGroupInvitesFragment.show(supportFragmentManager)
+      }
+    }
+
+    override fun onParentalControlsClick() {
+      val pc = SignalStore.parentalControl
+      if (pc.parentPinHash.isEmpty()) {
+        startActivity(
+          Intent(this@MainActivity, ParentalControlActivity::class.java)
+            .putExtra(ParentalControlActivity.EXTRA_SETUP_PIN, true)
+        )
+      } else {
+        ParentalPinDialog.show(this@MainActivity) {
+          startActivity(Intent(this@MainActivity, ParentalControlActivity::class.java))
+        }
       }
     }
   }

--- a/app/src/main/java/org/thoughtcrime/securesms/calls/log/CallLogPagedDataSource.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/calls/log/CallLogPagedDataSource.kt
@@ -16,7 +16,7 @@ class CallLogPagedDataSource(
   }
 
   private val hasFilter = filter == CallLogFilter.MISSED
-  private val hasCallLinkRow = filter == CallLogFilter.ALL && query.isNullOrEmpty()
+  private val hasCallLinkRow = filter == CallLogFilter.ALL && query.isNullOrEmpty() && !org.thoughtcrime.securesms.keyvalue.SignalStore.parentalControl.parentalModeEnabled
 
   private var callEventsCount = 0
   private var callLinksCount = 0

--- a/app/src/main/java/org/thoughtcrime/securesms/calls/new/NewCallActivity.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/calls/new/NewCallActivity.kt
@@ -47,6 +47,7 @@ import org.thoughtcrime.securesms.recipients.ui.RecipientPicker
 import org.thoughtcrime.securesms.recipients.ui.RecipientPickerCallbacks
 import org.thoughtcrime.securesms.recipients.ui.RecipientPickerScaffold
 import org.thoughtcrime.securesms.recipients.ui.RecipientSelection
+import org.thoughtcrime.securesms.keyvalue.SignalStore
 import org.thoughtcrime.securesms.util.CommunicationActions
 
 /**
@@ -61,6 +62,8 @@ class NewCallActivity : PassphraseRequiredActivity() {
   }
 
   override fun onCreate(savedInstanceState: Bundle?, ready: Boolean) {
+    if (SignalStore.parentalControl.parentalModeEnabled) { finish(); return }
+
     enableEdgeToEdge()
     super.onCreate(savedInstanceState, ready)
 

--- a/app/src/main/java/org/thoughtcrime/securesms/calls/new/NewCallActivity.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/calls/new/NewCallActivity.kt
@@ -46,6 +46,7 @@ import org.thoughtcrime.securesms.recipients.ui.RecipientPicker
 import org.thoughtcrime.securesms.recipients.ui.RecipientPickerCallbacks
 import org.thoughtcrime.securesms.recipients.ui.RecipientPickerScaffold
 import org.thoughtcrime.securesms.recipients.ui.RecipientSelection
+import org.thoughtcrime.securesms.keyvalue.SignalStore
 import org.thoughtcrime.securesms.util.CommunicationActions
 
 /**
@@ -60,6 +61,8 @@ class NewCallActivity : PassphraseRequiredActivity() {
   }
 
   override fun onCreate(savedInstanceState: Bundle?, ready: Boolean) {
+    if (SignalStore.parentalControl.parentalModeEnabled) { finish(); return }
+
     enableEdgeToEdge()
     super.onCreate(savedInstanceState, ready)
 

--- a/app/src/main/java/org/thoughtcrime/securesms/components/settings/app/AppSettingsFragment.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/components/settings/app/AppSettingsFragment.kt
@@ -74,6 +74,7 @@ import org.thoughtcrime.securesms.compose.rememberStatusBarColorNestedScrollModi
 import org.thoughtcrime.securesms.database.model.InAppPaymentSubscriberRecord
 import org.thoughtcrime.securesms.profiles.ProfileName
 import org.thoughtcrime.securesms.recipients.Recipient
+import org.thoughtcrime.securesms.keyvalue.SignalStore
 import org.thoughtcrime.securesms.util.CommunicationActions
 import org.thoughtcrime.securesms.util.SignalE164Util
 import org.thoughtcrime.securesms.util.navigation.safeNavigate
@@ -197,6 +198,7 @@ private fun AppSettingsContent(
   callbacks: Callbacks
 ) {
   val isRegisteredAndUpToDate by rememberUpdatedState(state.isRegisteredAndUpToDate())
+  val parentalModeEnabled = SignalStore.parentalControl.parentalModeEnabled
 
   Scaffolds.Settings(
     title = stringResource(R.string.text_secure_normal__menu_settings),
@@ -287,42 +289,44 @@ private fun AppSettingsContent(
           BackupFailureState.NONE -> Unit
         }
 
-        item {
-          Rows.TextRow(
-            text = stringResource(R.string.AccountSettingsFragment__account),
-            icon = painterResource(R.drawable.symbol_person_circle_24),
-            onClick = {
-              callbacks.navigate(AppSettingsRoute.AccountRoute.Account)
-            }
-          )
-        }
+        if (!parentalModeEnabled) {
+          item {
+            Rows.TextRow(
+              text = stringResource(R.string.AccountSettingsFragment__account),
+              icon = painterResource(R.drawable.symbol_person_circle_24),
+              onClick = {
+                callbacks.navigate(AppSettingsRoute.AccountRoute.Account)
+              }
+            )
+          }
 
-        item {
-          Rows.TextRow(
-            text = stringResource(R.string.preferences__linked_devices),
-            icon = painterResource(R.drawable.symbol_devices_24),
-            onClick = {
-              callbacks.navigate(AppSettingsRoute.LinkDeviceRoute.LinkDevice)
-            },
-            enabled = isRegisteredAndUpToDate
-          )
-        }
+          item {
+            Rows.TextRow(
+              text = stringResource(R.string.preferences__linked_devices),
+              icon = painterResource(R.drawable.symbol_devices_24),
+              onClick = {
+                callbacks.navigate(AppSettingsRoute.LinkDeviceRoute.LinkDevice)
+              },
+              enabled = isRegisteredAndUpToDate
+            )
+          }
 
-        item {
-          val context = LocalContext.current
-          val donateUrl = stringResource(R.string.donate_url)
+          item {
+            val context = LocalContext.current
+            val donateUrl = stringResource(R.string.donate_url)
 
-          Rows.TextRow(
-            text = stringResource(R.string.preferences__donate_to_signal),
-            icon = painterResource(R.drawable.symbol_heart_24),
-            onClick = {
-              CommunicationActions.openBrowserLink(context, donateUrl)
-            },
-          )
-        }
+            Rows.TextRow(
+              text = stringResource(R.string.preferences__donate_to_signal),
+              icon = painterResource(R.drawable.symbol_heart_24),
+              onClick = {
+                CommunicationActions.openBrowserLink(context, donateUrl)
+              },
+            )
+          }
 
-        item {
-          Dividers.Default()
+          item {
+            Dividers.Default()
+          }
         }
 
         item {

--- a/app/src/main/java/org/thoughtcrime/securesms/components/settings/app/AppSettingsFragment.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/components/settings/app/AppSettingsFragment.kt
@@ -74,6 +74,7 @@ import org.thoughtcrime.securesms.compose.rememberStatusBarColorNestedScrollModi
 import org.thoughtcrime.securesms.database.model.InAppPaymentSubscriberRecord
 import org.thoughtcrime.securesms.profiles.ProfileName
 import org.thoughtcrime.securesms.recipients.Recipient
+import org.thoughtcrime.securesms.keyvalue.SignalStore
 import org.thoughtcrime.securesms.util.CommunicationActions
 import org.thoughtcrime.securesms.util.SignalE164Util
 import org.thoughtcrime.securesms.util.navigation.safeNavigate
@@ -198,6 +199,7 @@ private fun AppSettingsContent(
   callbacks: Callbacks
 ) {
   val isRegisteredAndUpToDate by rememberUpdatedState(state.isRegisteredAndUpToDate())
+  val parentalModeEnabled = SignalStore.parentalControl.parentalModeEnabled
 
   Scaffolds.Settings(
     title = stringResource(R.string.text_secure_normal__menu_settings),
@@ -288,42 +290,44 @@ private fun AppSettingsContent(
           BackupFailureState.NONE -> Unit
         }
 
-        item {
-          Rows.TextRow(
-            text = stringResource(R.string.AccountSettingsFragment__account),
-            icon = painterResource(CoreUiR.drawable.symbol_person_circle_24),
-            onClick = {
-              callbacks.navigate(AppSettingsRoute.AccountRoute.Account)
-            }
-          )
-        }
+        if (!parentalModeEnabled) {
+          item {
+            Rows.TextRow(
+              text = stringResource(R.string.AccountSettingsFragment__account),
+              icon = painterResource(CoreUiR.drawable.symbol_person_circle_24),
+              onClick = {
+                callbacks.navigate(AppSettingsRoute.AccountRoute.Account)
+              }
+            )
+          }
 
-        item {
-          Rows.TextRow(
-            text = stringResource(R.string.preferences__linked_devices),
-            icon = painterResource(CoreUiR.drawable.symbol_devices_24),
-            onClick = {
-              callbacks.navigate(AppSettingsRoute.LinkDeviceRoute.LinkDevice)
-            },
-            enabled = isRegisteredAndUpToDate
-          )
-        }
+          item {
+            Rows.TextRow(
+              text = stringResource(R.string.preferences__linked_devices),
+              icon = painterResource(CoreUiR.drawable.symbol_devices_24),
+              onClick = {
+                callbacks.navigate(AppSettingsRoute.LinkDeviceRoute.LinkDevice)
+              },
+              enabled = isRegisteredAndUpToDate
+            )
+          }
 
-        item {
-          val context = LocalContext.current
-          val donateUrl = stringResource(R.string.donate_url)
+          item {
+            val context = LocalContext.current
+            val donateUrl = stringResource(R.string.donate_url)
 
-          Rows.TextRow(
-            text = stringResource(R.string.preferences__donate_to_signal),
-            icon = painterResource(R.drawable.symbol_heart_24),
-            onClick = {
-              CommunicationActions.openBrowserLink(context, donateUrl)
-            },
-          )
-        }
+            Rows.TextRow(
+              text = stringResource(R.string.preferences__donate_to_signal),
+              icon = painterResource(R.drawable.symbol_heart_24),
+              onClick = {
+                CommunicationActions.openBrowserLink(context, donateUrl)
+              },
+            )
+          }
 
-        item {
-          Dividers.Default()
+          item {
+            Dividers.Default()
+          }
         }
 
         item {

--- a/app/src/main/java/org/thoughtcrime/securesms/components/settings/app/privacy/PrivacySettingsFragment.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/components/settings/app/privacy/PrivacySettingsFragment.kt
@@ -255,15 +255,17 @@ class PrivacySettingsFragment : DSLSettingsFragment(R.string.preferences__privac
         summary = DSLSettingsText.from(incognitoSummary)
       )
 
-      dividerPref()
+      if (!SignalStore.parentalControl.parentalModeEnabled) {
+        dividerPref()
 
-      clickPref(
-        title = DSLSettingsText.from(R.string.preferences__advanced),
-        summary = DSLSettingsText.from(R.string.PrivacySettingsFragment__signal_message_and_calls),
-        onClick = {
-          Navigation.findNavController(requireView()).safeNavigate(R.id.action_privacySettingsFragment_to_advancedPrivacySettingsFragment)
-        }
-      )
+        clickPref(
+          title = DSLSettingsText.from(R.string.preferences__advanced),
+          summary = DSLSettingsText.from(R.string.PrivacySettingsFragment__signal_message_and_calls),
+          onClick = {
+            Navigation.findNavController(requireView()).safeNavigate(R.id.action_privacySettingsFragment_to_advancedPrivacySettingsFragment)
+          }
+        )
+      }
     }
   }
 

--- a/app/src/main/java/org/thoughtcrime/securesms/components/settings/conversation/ConversationSettingsActivity.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/components/settings/conversation/ConversationSettingsActivity.kt
@@ -11,6 +11,7 @@ import com.google.android.material.transition.platform.MaterialContainerTransfor
 import org.thoughtcrime.securesms.R
 import org.thoughtcrime.securesms.components.settings.DSLSettingsActivity
 import org.thoughtcrime.securesms.groups.GroupId
+import org.thoughtcrime.securesms.keyvalue.SignalStore
 import org.thoughtcrime.securesms.recipients.Recipient
 import org.thoughtcrime.securesms.recipients.RecipientId
 import org.thoughtcrime.securesms.util.DynamicConversationSettingsTheme
@@ -21,6 +22,10 @@ open class ConversationSettingsActivity : DSLSettingsActivity(), ConversationSet
   override val dynamicTheme: DynamicTheme = DynamicConversationSettingsTheme()
 
   override fun onCreate(savedInstanceState: Bundle?, ready: Boolean) {
+    if (SignalStore.parentalControl.parentalModeEnabled && intent.getBooleanExtra(EXTRA_IS_GROUP, false)) {
+      finish()
+      return
+    }
     ActivityCompat.postponeEnterTransition(this)
     setExitSharedElementCallback(MaterialContainerTransformSharedElementCallback())
     super.onCreate(savedInstanceState, ready)
@@ -73,6 +78,7 @@ open class ConversationSettingsActivity : DSLSettingsActivity(), ConversationSet
 
       return getIntent(context)
         .putExtra(ARG_START_BUNDLE, startBundle)
+        .putExtra(EXTRA_IS_GROUP, true)
     }
 
     @JvmStatic
@@ -104,5 +110,7 @@ open class ConversationSettingsActivity : DSLSettingsActivity(), ConversationSet
       return Intent(context, ConversationSettingsActivity::class.java)
         .putExtra(ARG_NAV_GRAPH, R.navigation.conversation_settings)
     }
+
+    private const val EXTRA_IS_GROUP = "parental_is_group"
   }
 }

--- a/app/src/main/java/org/thoughtcrime/securesms/components/settings/conversation/ConversationSettingsActivity.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/components/settings/conversation/ConversationSettingsActivity.kt
@@ -8,6 +8,7 @@ import com.google.android.material.transition.platform.MaterialContainerTransfor
 import org.thoughtcrime.securesms.R
 import org.thoughtcrime.securesms.components.settings.DSLSettingsActivity
 import org.thoughtcrime.securesms.groups.GroupId
+import org.thoughtcrime.securesms.keyvalue.SignalStore
 import org.thoughtcrime.securesms.recipients.Recipient
 import org.thoughtcrime.securesms.recipients.RecipientId
 import org.thoughtcrime.securesms.util.DynamicConversationSettingsTheme
@@ -18,6 +19,10 @@ open class ConversationSettingsActivity : DSLSettingsActivity(), ConversationSet
   override val dynamicTheme: DynamicTheme = DynamicConversationSettingsTheme()
 
   override fun onCreate(savedInstanceState: Bundle?, ready: Boolean) {
+    if (SignalStore.parentalControl.parentalModeEnabled && intent.getBooleanExtra(EXTRA_IS_GROUP, false)) {
+      finish()
+      return
+    }
     ActivityCompat.postponeEnterTransition(this)
     setExitSharedElementCallback(MaterialContainerTransformSharedElementCallback())
     super.onCreate(savedInstanceState, ready)
@@ -41,6 +46,7 @@ open class ConversationSettingsActivity : DSLSettingsActivity(), ConversationSet
 
       return getIntent(context)
         .putExtra(ARG_START_BUNDLE, startBundle)
+        .putExtra(EXTRA_IS_GROUP, true)
     }
 
     @JvmStatic
@@ -72,5 +78,7 @@ open class ConversationSettingsActivity : DSLSettingsActivity(), ConversationSet
       return Intent(context, ConversationSettingsActivity::class.java)
         .putExtra(ARG_NAV_GRAPH, R.navigation.conversation_settings)
     }
+
+    private const val EXTRA_IS_GROUP = "parental_is_group"
   }
 }

--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/ConversationOptionsMenu.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/ConversationOptionsMenu.kt
@@ -128,6 +128,9 @@ internal object ConversationOptionsMenu {
           }
         }
         menuInflater.inflate(R.menu.conversation_active_group_options, menu)
+        if (SignalStore.parentalControl.parentalModeEnabled) {
+          hideMenuItem(menu, R.id.menu_group_settings)
+        }
       }
 
       menuInflater.inflate(R.menu.conversation, menu)

--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/NewConversationActivity.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/NewConversationActivity.kt
@@ -58,6 +58,7 @@ import org.thoughtcrime.securesms.recipients.ui.RecipientPickerScaffold
 import org.thoughtcrime.securesms.recipients.ui.RecipientSelection
 import org.thoughtcrime.securesms.recipients.ui.findby.FindByActivity
 import org.thoughtcrime.securesms.recipients.ui.findby.FindByMode
+import org.thoughtcrime.securesms.keyvalue.SignalStore
 import org.thoughtcrime.securesms.util.CommunicationActions
 import org.thoughtcrime.securesms.util.DynamicNoActionBarTheme
 
@@ -88,6 +89,8 @@ class NewConversationActivity : PassphraseRequiredActivity() {
   }
 
   override fun onCreate(savedInstanceState: Bundle?, ready: Boolean) {
+    if (SignalStore.parentalControl.parentalModeEnabled) { finish(); return }
+
     enableEdgeToEdge()
     super.onCreate(savedInstanceState, ready)
 

--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/NewConversationActivity.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/NewConversationActivity.kt
@@ -60,6 +60,7 @@ import org.thoughtcrime.securesms.recipients.ui.RecipientPickerScaffold
 import org.thoughtcrime.securesms.recipients.ui.RecipientSelection
 import org.thoughtcrime.securesms.recipients.ui.findby.FindByActivity
 import org.thoughtcrime.securesms.recipients.ui.findby.FindByMode
+import org.thoughtcrime.securesms.keyvalue.SignalStore
 import org.thoughtcrime.securesms.util.CommunicationActions
 import org.thoughtcrime.securesms.util.DynamicNoActionBarTheme
 
@@ -90,6 +91,8 @@ class NewConversationActivity : PassphraseRequiredActivity() {
   }
 
   override fun onCreate(savedInstanceState: Bundle?, ready: Boolean) {
+    if (SignalStore.parentalControl.parentalModeEnabled) { finish(); return }
+
     enableEdgeToEdge()
     super.onCreate(savedInstanceState, ready)
 

--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/ConversationFragment.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/ConversationFragment.kt
@@ -4240,6 +4240,11 @@ class ConversationFragment :
    * In split-pane mode, delegates to the [MainNavigationRouter] to display content in the detail pane. Otherwise, opens the destination as a standalone screen.
    */
   private fun navigateTo(location: MainNavigationDetailLocation.Chats) {
+    if (SignalStore.parentalControl.parentalModeEnabled &&
+      location is MainNavigationDetailLocation.Chats.ConversationSettings &&
+      viewModel.recipientSnapshot?.isPushGroup == true
+    ) return
+
     val router = mainNavRouter
     if (router != null && resources.getWindowSizeClass().isSplitPane()) {
       router.goTo(location)
@@ -4264,6 +4269,8 @@ class ConversationFragment :
    * Opens conversation settings as a standalone (single-pane) screen.
    */
   private fun navigateToConversationSettingsStandalone(recipient: Recipient) {
+    if (SignalStore.parentalControl.parentalModeEnabled && recipient.isPushGroup) return
+
     val intent = if (recipient.isPushGroup) {
       ConversationSettingsActivity.forGroup(requireContext(), recipient.requireGroupId())
     } else {

--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/ConversationFragment.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/ConversationFragment.kt
@@ -291,6 +291,7 @@ import org.thoughtcrime.securesms.mediapreview.MediaPreviewV2Activity
 import org.thoughtcrime.securesms.mediasend.MediaSendActivityResult
 import org.thoughtcrime.securesms.messagedetails.MessageDetailsFragment
 import org.thoughtcrime.securesms.messagerequests.MessageRequestRepository
+import org.thoughtcrime.securesms.messagerequests.MessageRequestState
 import org.thoughtcrime.securesms.mms.AttachmentManager
 import org.thoughtcrime.securesms.mms.AudioSlide
 import org.thoughtcrime.securesms.mms.DocumentSlide
@@ -1532,7 +1533,14 @@ class ConversationFragment :
       inputReadyState.isClientExpired || inputReadyState.isUnauthorized -> disabledInputView.showAsExpiredOrUnauthorized(inputReadyState.isClientExpired, inputReadyState.isUnauthorized)
       args.isIncognito -> disabledInputView.showAsIncognito()
       inputReadyState.isTerminatedGroup -> disabledInputView.showAsTerminatedGroup()
-      !inputReadyState.messageRequestState.isAccepted -> disabledInputView.showAsMessageRequest(inputReadyState.conversationRecipient, inputReadyState.messageRequestState)
+      !inputReadyState.messageRequestState.isAccepted -> {
+        val isGroupInvite = inputReadyState.messageRequestState.state == MessageRequestState.State.GROUP_V2_INVITE
+        if (isGroupInvite && SignalStore.parentalControl.parentalModeEnabled) {
+          disabledInputView.clear()
+        } else {
+          disabledInputView.showAsMessageRequest(inputReadyState.conversationRecipient, inputReadyState.messageRequestState)
+        }
+      }
       inputReadyState.isRequestingMember == true -> disabledInputView.showAsRequestingMember()
       inputReadyState.isActiveGroup == false -> disabledInputView.showAsNoLongerAMember()
       inputReadyState.isAnnouncementGroup == true && inputReadyState.isAdmin == false -> disabledInputView.showAsAnnouncementGroupAdminsOnly()

--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/ConversationFragment.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/ConversationFragment.kt
@@ -300,6 +300,7 @@ import org.thoughtcrime.securesms.mediapreview.MediaIntentFactory
 import org.thoughtcrime.securesms.mediapreview.MediaPreviewV2Activity
 import org.thoughtcrime.securesms.mediasend.MediaSendActivityResult
 import org.thoughtcrime.securesms.messagerequests.MessageRequestRepository
+import org.thoughtcrime.securesms.messagerequests.MessageRequestState
 import org.thoughtcrime.securesms.mms.AttachmentManager
 import org.thoughtcrime.securesms.mms.AudioSlide
 import org.thoughtcrime.securesms.mms.DocumentSlide
@@ -1597,7 +1598,14 @@ class ConversationFragment :
       inputReadyState.isClientExpired || inputReadyState.isUnauthorized -> disabledInputView.showAsExpiredOrUnauthorized(inputReadyState.isClientExpired, inputReadyState.isUnauthorized)
       args.isIncognito -> disabledInputView.showAsIncognito()
       inputReadyState.isTerminatedGroup -> disabledInputView.showAsTerminatedGroup()
-      !inputReadyState.messageRequestState.isAccepted -> disabledInputView.showAsMessageRequest(inputReadyState.conversationRecipient, inputReadyState.messageRequestState)
+      !inputReadyState.messageRequestState.isAccepted -> {
+        val isGroupInvite = inputReadyState.messageRequestState.state == MessageRequestState.State.GROUP_V2_INVITE
+        if (isGroupInvite && SignalStore.parentalControl.parentalModeEnabled) {
+          disabledInputView.clear()
+        } else {
+          disabledInputView.showAsMessageRequest(inputReadyState.conversationRecipient, inputReadyState.messageRequestState)
+        }
+      }
       inputReadyState.isRequestingMember == true -> disabledInputView.showAsRequestingMember()
       inputReadyState.isActiveGroup == false -> disabledInputView.showAsNoLongerAMember()
       inputReadyState.isAnnouncementGroup == true && inputReadyState.isAdmin == false -> disabledInputView.showAsAnnouncementGroupAdminsOnly()

--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/ConversationFragment.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/ConversationFragment.kt
@@ -4294,6 +4294,8 @@ class ConversationFragment :
 
     override fun handleManageGroup() {
       viewModel.recipientSnapshot?.let { recipient ->
+        if (SignalStore.parentalControl.parentalModeEnabled && recipient.isPushGroup) return
+
         container.hideKeyboard(composeText)
         chatRouter.goToChatDetail(MainNavigationDetailLocation.Chats.ConversationSettings(recipient.id))
       }
@@ -4331,6 +4333,8 @@ class ConversationFragment :
 
     override fun handleConversationSettings() {
       viewModel.recipientSnapshot?.let { recipient ->
+        if (SignalStore.parentalControl.parentalModeEnabled && recipient.isPushGroup) return
+
         if (!viewModel.hasMessageRequestState || recipient.isBlocked) {
           container.hideKeyboard(composeText)
           chatRouter.goToChatDetail(MainNavigationDetailLocation.Chats.ConversationSettings(recipient.id))

--- a/app/src/main/java/org/thoughtcrime/securesms/conversationlist/ConversationListViewModel.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversationlist/ConversationListViewModel.kt
@@ -51,6 +51,17 @@ sealed class ConversationListViewModel(
     private const val STATE = "state"
 
     private var coldStart = true
+
+    internal fun applyParentalFilter(
+      list: List<Conversation>,
+      enabled: Boolean,
+      allowedIds: Set<Long>
+    ): List<Conversation> {
+      if (!enabled) return list
+      return list.filter { conv ->
+        conv.type != Conversation.Type.THREAD || conv.threadRecord.threadId in allowedIds
+      }
+    }
   }
 
   private val disposables: CompositeDisposable = CompositeDisposable()
@@ -69,6 +80,13 @@ sealed class ConversationListViewModel(
     .build()
 
   val conversationsState: Flowable<List<Conversation>> = store.mapDistinctForUi { it.conversations }
+    .map { list ->
+      applyParentalFilter(
+        list,
+        SignalStore.parentalControl.parentalModeEnabled,
+        SignalStore.parentalControl.getAllowedThreadIds()
+      )
+    }
   val selectedState: Flowable<ConversationSet> = store.mapDistinctForUi { it.selectedConversations }
   val filterRequestState: Flowable<ConversationFilterRequest> = savedStateHandle.getStateFlow(STATE, SaveableState()).map { it.filterRequest }.asFlowable().observeOn(AndroidSchedulers.mainThread())
   val chatFolderState: Flowable<List<ChatFolderMappingModel>> = savedStateHandle.getStateFlow(STATE, SaveableState()).map { it.chatFolders }.asFlowable().observeOn(AndroidSchedulers.mainThread())
@@ -121,6 +139,12 @@ sealed class ConversationListViewModel(
     RxDatabaseObserver
       .conversationList
       .throttleLatest(500, TimeUnit.MILLISECONDS)
+      .subscribe { controller.onDataInvalidated() }
+      .addTo(disposables)
+
+    SignalStore.parentalControl.settingsChanges
+      .toFlowable(BackpressureStrategy.LATEST)
+      .observeOn(Schedulers.io())
       .subscribe { controller.onDataInvalidated() }
       .addTo(disposables)
 

--- a/app/src/main/java/org/thoughtcrime/securesms/conversationlist/ConversationListViewModel.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversationlist/ConversationListViewModel.kt
@@ -79,7 +79,10 @@ sealed class ConversationListViewModel(
     .setBufferPages(2)
     .build()
 
-  val conversationsState: Flowable<List<Conversation>> = store.mapDistinctForUi { it.conversations }
+  val conversationsState: Flowable<List<Conversation>> = Flowable.combineLatest(
+    store.mapDistinctForUi { it.conversations },
+    SignalStore.parentalControl.settingsChanges.startWithItem(Unit).toFlowable(BackpressureStrategy.LATEST)
+  ) { list, _ -> list }
     .map { list ->
       applyParentalFilter(
         list,
@@ -139,12 +142,6 @@ sealed class ConversationListViewModel(
     RxDatabaseObserver
       .conversationList
       .throttleLatest(500, TimeUnit.MILLISECONDS)
-      .subscribe { controller.onDataInvalidated() }
-      .addTo(disposables)
-
-    SignalStore.parentalControl.settingsChanges
-      .toFlowable(BackpressureStrategy.LATEST)
-      .observeOn(Schedulers.io())
       .subscribe { controller.onDataInvalidated() }
       .addTo(disposables)
 

--- a/app/src/main/java/org/thoughtcrime/securesms/keyvalue/ParentalControlValues.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/keyvalue/ParentalControlValues.kt
@@ -48,6 +48,24 @@ class ParentalControlValues internal constructor(store: KeyValueStore) : SignalS
     settingsChanges.onNext(Unit)
   }
 
+  /** Returns true if the provided [pin] matches the stored parent PIN hash. */
+  fun verifyPin(pin: String): Boolean {
+    val hash = parentPinHash
+    if (hash.isEmpty()) return false
+    return computePinHash(pin, getPinSalt()) == hash
+  }
+
+  /** Adds [threadId] to the allowed set without clearing existing entries. */
+  fun addAllowedThreadId(threadId: Long) {
+    setAllowedThreadIds(getAllowedThreadIds() + threadId)
+  }
+
+  /** Returns true if an incoming/outgoing call on [threadId] is permitted in parental mode. */
+  fun isThreadCallAllowed(threadId: Long): Boolean {
+    if (!parentalModeEnabled) return true
+    return threadId in getAllowedThreadIds()
+  }
+
   public override fun onFirstEverAppLaunch() = Unit
 
   public override fun getKeysToIncludeInBackup(): List<String> = emptyList()

--- a/app/src/main/java/org/thoughtcrime/securesms/keyvalue/ParentalControlValues.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/keyvalue/ParentalControlValues.kt
@@ -23,6 +23,8 @@ class ParentalControlValues internal constructor(store: KeyValueStore) : SignalS
 
   val settingsChanges: PublishSubject<Unit> = PublishSubject.create()
 
+  fun notifyChanged() = settingsChanges.onNext(Unit)
+
   var parentalModeEnabled: Boolean
     get() = getBoolean(KEY_PARENTAL_MODE_ENABLED, true)
     set(value) {

--- a/app/src/main/java/org/thoughtcrime/securesms/keyvalue/ParentalControlValues.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/keyvalue/ParentalControlValues.kt
@@ -1,0 +1,50 @@
+package org.thoughtcrime.securesms.keyvalue
+
+import org.signal.core.util.StringSerializer
+import java.security.MessageDigest
+import java.security.SecureRandom
+
+class ParentalControlValues internal constructor(store: KeyValueStore) : SignalStoreValues(store) {
+
+  companion object {
+    private const val KEY_PARENTAL_MODE_ENABLED = "pc.parental_mode_enabled"
+    private const val KEY_PARENT_PIN_HASH = "pc.parent_pin_hash"
+    private const val KEY_PIN_SALT = "pc.pin_salt"
+    private const val KEY_ALLOWED_THREAD_IDS = "pc.allowed_thread_ids"
+
+    fun computePinHash(pin: String, salt: ByteArray): String {
+      val digest = MessageDigest.getInstance("SHA-256")
+      digest.update(salt)
+      digest.update(pin.toByteArray(Charsets.UTF_8))
+      return digest.digest().joinToString("") { "%02x".format(it) }
+    }
+  }
+
+  var parentalModeEnabled: Boolean by booleanValue(KEY_PARENTAL_MODE_ENABLED, true)
+
+  var parentPinHash: String by stringValue(KEY_PARENT_PIN_HASH, "")
+
+  fun getPinSalt(): ByteArray {
+    return getBlob(KEY_PIN_SALT, null) ?: ByteArray(16).also {
+      SecureRandom().nextBytes(it)
+      putBlob(KEY_PIN_SALT, it)
+    }
+  }
+
+  fun getAllowedThreadIds(): Set<Long> {
+    return getList(KEY_ALLOWED_THREAD_IDS, LongSerializer).toSet()
+  }
+
+  fun setAllowedThreadIds(ids: Set<Long>) {
+    putList(KEY_ALLOWED_THREAD_IDS, ids.toList(), LongSerializer)
+  }
+
+  public override fun onFirstEverAppLaunch() = Unit
+
+  public override fun getKeysToIncludeInBackup(): List<String> = emptyList()
+
+  private object LongSerializer : StringSerializer<Long> {
+    override fun serialize(data: Long): String = data.toString()
+    override fun deserialize(data: String): Long = data.toLong()
+  }
+}

--- a/app/src/main/java/org/thoughtcrime/securesms/keyvalue/ParentalControlValues.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/keyvalue/ParentalControlValues.kt
@@ -1,5 +1,6 @@
 package org.thoughtcrime.securesms.keyvalue
 
+import io.reactivex.rxjava3.subjects.PublishSubject
 import org.signal.core.util.StringSerializer
 import java.security.MessageDigest
 import java.security.SecureRandom
@@ -20,7 +21,14 @@ class ParentalControlValues internal constructor(store: KeyValueStore) : SignalS
     }
   }
 
-  var parentalModeEnabled: Boolean by booleanValue(KEY_PARENTAL_MODE_ENABLED, true)
+  val settingsChanges: PublishSubject<Unit> = PublishSubject.create()
+
+  var parentalModeEnabled: Boolean
+    get() = getBoolean(KEY_PARENTAL_MODE_ENABLED, true)
+    set(value) {
+      putBoolean(KEY_PARENTAL_MODE_ENABLED, value)
+      settingsChanges.onNext(Unit)
+    }
 
   var parentPinHash: String by stringValue(KEY_PARENT_PIN_HASH, "")
 
@@ -37,6 +45,7 @@ class ParentalControlValues internal constructor(store: KeyValueStore) : SignalS
 
   fun setAllowedThreadIds(ids: Set<Long>) {
     putList(KEY_ALLOWED_THREAD_IDS, ids.toList(), LongSerializer)
+    settingsChanges.onNext(Unit)
   }
 
   public override fun onFirstEverAppLaunch() = Unit

--- a/app/src/main/java/org/thoughtcrime/securesms/keyvalue/SignalStore.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/keyvalue/SignalStore.kt
@@ -39,6 +39,7 @@ class SignalStore(context: Application, private val store: KeyValueStore) {
   val backupValues = BackupValues(store)
   val unifiedPushValues = UnifiedPushValues(store)
   val labsValues = LabsValues(store)
+  val parentalControlValues = ParentalControlValues(store)
 
   val plainTextValues = PlainTextSharedPrefsDataStore(context)
 
@@ -88,6 +89,7 @@ class SignalStore(context: Application, private val store: KeyValueStore) {
       backup.onFirstEverAppLaunch()
       unifiedpush.onFirstEverAppLaunch()
       labs.onFirstEverAppLaunch()
+      parentalControl.onFirstEverAppLaunch()
     }
 
     @JvmStatic
@@ -281,6 +283,11 @@ class SignalStore(context: Application, private val store: KeyValueStore) {
     @get:JvmName("labs")
     val labs: LabsValues
       get() = instance!!.labsValues
+
+    @JvmStatic
+    @get:JvmName("parentalControl")
+    val parentalControl: ParentalControlValues
+      get() = instance!!.parentalControlValues
 
     val groupsV2AciAuthorizationCache: GroupsV2AuthorizationSignalStoreCache
       get() = GroupsV2AuthorizationSignalStoreCache.createAciCache(instance!!.store)

--- a/app/src/main/java/org/thoughtcrime/securesms/main/MainFloatingActionButtons.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/main/MainFloatingActionButtons.kt
@@ -41,6 +41,7 @@ import org.signal.core.ui.compose.Previews
 import org.signal.core.ui.compose.SignalIcons
 import org.signal.core.ui.compose.theme.SignalTheme
 import org.thoughtcrime.securesms.R
+import org.thoughtcrime.securesms.keyvalue.SignalStore
 import org.thoughtcrime.securesms.window.NavigationType
 import kotlin.math.roundToInt
 import org.signal.core.ui.R as CoreUiR
@@ -170,6 +171,8 @@ private fun PrimaryActionButton(
   onCameraClick: (MainNavigationListLocation) -> Unit = {},
   onNewCallClick: () -> Unit = {}
 ) {
+  if (SignalStore.parentalControl.parentalModeEnabled && destination != MainNavigationListLocation.STORIES) return
+
   val onClick = remember(destination) {
     when (destination) {
       MainNavigationListLocation.ARCHIVE -> onNewChatClick

--- a/app/src/main/java/org/thoughtcrime/securesms/main/MainNavigation.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/main/MainNavigation.kt
@@ -60,8 +60,18 @@ import org.signal.core.ui.compose.DayNightPreviews
 import org.signal.core.ui.compose.Previews
 import org.signal.core.ui.compose.theme.colorAttribute
 import org.thoughtcrime.securesms.R
+import org.thoughtcrime.securesms.keyvalue.SignalStore
 
 private val LOTTIE_SIZE = 28.dp
+
+internal fun buildNavEntries(isStoriesEnabled: Boolean, parentalModeEnabled: Boolean): List<MainNavigationListLocation> {
+  val hideStories = !isStoriesEnabled || parentalModeEnabled
+  return if (hideStories) {
+    MainNavigationListLocation.entries.filterNot { it == MainNavigationListLocation.STORIES || it == MainNavigationListLocation.ARCHIVE }
+  } else {
+    MainNavigationListLocation.entries.filterNot { it == MainNavigationListLocation.ARCHIVE }
+  }
+}
 
 enum class MainNavigationListLocation(
   @StringRes val label: Int,
@@ -110,12 +120,9 @@ fun MainNavigationBar(
     modifier = Modifier.height(if (state.compact) 48.dp else 80.dp),
     windowInsets = WindowInsets(0, 0, 0, 0)
   ) {
-    val entries = remember(state.isStoriesFeatureEnabled) {
-      if (state.isStoriesFeatureEnabled) {
-        MainNavigationListLocation.entries.filterNot { it == MainNavigationListLocation.ARCHIVE }
-      } else {
-        MainNavigationListLocation.entries.filterNot { it == MainNavigationListLocation.STORIES || it == MainNavigationListLocation.ARCHIVE }
-      }
+    val parentalModeEnabled = SignalStore.parentalControl.parentalModeEnabled
+    val entries = remember(state.isStoriesFeatureEnabled, parentalModeEnabled) {
+      buildNavEntries(state.isStoriesFeatureEnabled, parentalModeEnabled)
     }
 
     entries.forEach { destination ->
@@ -233,12 +240,9 @@ fun MainNavigationRail(
 
     Spacer(modifier = Modifier.height(40.dp).weight(1f, fill = false))
 
-    val entries = remember(state.isStoriesFeatureEnabled) {
-      if (state.isStoriesFeatureEnabled) {
-        MainNavigationListLocation.entries.filterNot { it == MainNavigationListLocation.ARCHIVE }
-      } else {
-        MainNavigationListLocation.entries.filterNot { it == MainNavigationListLocation.STORIES || it == MainNavigationListLocation.ARCHIVE }
-      }
+    val parentalModeEnabled = SignalStore.parentalControl.parentalModeEnabled
+    val entries = remember(state.isStoriesFeatureEnabled, parentalModeEnabled) {
+      buildNavEntries(state.isStoriesFeatureEnabled, parentalModeEnabled)
     }
 
     val selectedDestination = if (state.currentListLocation == MainNavigationListLocation.ARCHIVE) {

--- a/app/src/main/java/org/thoughtcrime/securesms/main/MainNavigation.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/main/MainNavigation.kt
@@ -60,8 +60,18 @@ import org.signal.core.ui.compose.DayNightPreviews
 import org.signal.core.ui.compose.Previews
 import org.signal.core.ui.compose.theme.colorAttribute
 import org.thoughtcrime.securesms.R
+import org.thoughtcrime.securesms.keyvalue.SignalStore
 
 private val LOTTIE_SIZE = 28.dp
+
+internal fun buildNavEntries(isStoriesEnabled: Boolean, parentalModeEnabled: Boolean): List<MainNavigationListLocation> {
+  val hideStories = !isStoriesEnabled || parentalModeEnabled
+  return if (hideStories) {
+    MainNavigationListLocation.entries.filterNot { it == MainNavigationListLocation.STORIES || it == MainNavigationListLocation.ARCHIVE }
+  } else {
+    MainNavigationListLocation.entries.filterNot { it == MainNavigationListLocation.ARCHIVE }
+  }
+}
 
 enum class MainNavigationListLocation(
   @StringRes val label: Int,
@@ -113,12 +123,9 @@ fun MainNavigationBar(
     modifier = Modifier.height(if (state.compact) 48.dp else 80.dp),
     windowInsets = WindowInsets(0, 0, 0, 0)
   ) {
-    val entries = remember(state.isStoriesFeatureEnabled) {
-      if (state.isStoriesFeatureEnabled) {
-        MainNavigationListLocation.entries.filterNot { it == MainNavigationListLocation.ARCHIVE }
-      } else {
-        MainNavigationListLocation.entries.filterNot { it == MainNavigationListLocation.STORIES || it == MainNavigationListLocation.ARCHIVE }
-      }
+    val parentalModeEnabled = SignalStore.parentalControl.parentalModeEnabled
+    val entries = remember(state.isStoriesFeatureEnabled, parentalModeEnabled) {
+      buildNavEntries(state.isStoriesFeatureEnabled, parentalModeEnabled)
     }
 
     entries.forEach { destination ->
@@ -236,12 +243,9 @@ fun MainNavigationRail(
 
     Spacer(modifier = Modifier.height(40.dp).weight(1f, fill = false))
 
-    val entries = remember(state.isStoriesFeatureEnabled) {
-      if (state.isStoriesFeatureEnabled) {
-        MainNavigationListLocation.entries.filterNot { it == MainNavigationListLocation.ARCHIVE }
-      } else {
-        MainNavigationListLocation.entries.filterNot { it == MainNavigationListLocation.STORIES || it == MainNavigationListLocation.ARCHIVE }
-      }
+    val parentalModeEnabled = SignalStore.parentalControl.parentalModeEnabled
+    val entries = remember(state.isStoriesFeatureEnabled, parentalModeEnabled) {
+      buildNavEntries(state.isStoriesFeatureEnabled, parentalModeEnabled)
     }
 
     val selectedDestination = if (state.currentListLocation == MainNavigationListLocation.ARCHIVE) {

--- a/app/src/main/java/org/thoughtcrime/securesms/main/MainNavigationRepository.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/main/MainNavigationRepository.kt
@@ -4,12 +4,21 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.reactive.asFlow
 import org.thoughtcrime.securesms.database.RxDatabaseObserver
 import org.thoughtcrime.securesms.database.SignalDatabase
+import org.thoughtcrime.securesms.keyvalue.SignalStore
 import org.thoughtcrime.securesms.recipients.Recipient
 
 object MainNavigationRepository {
 
   fun getNumberOfUnreadMessages(): Flow<Long> {
-    return RxDatabaseObserver.conversationList.map { SignalDatabase.threads.getUnreadMessageCount() }.asFlow()
+    return RxDatabaseObserver.conversationList.map {
+      if (SignalStore.parentalControl.parentalModeEnabled) {
+        SignalStore.parentalControl.getAllowedThreadIds().sumOf { threadId ->
+          SignalDatabase.threads.getThreadRecord(threadId)?.unreadCount?.toLong() ?: 0L
+        }
+      } else {
+        SignalDatabase.threads.getUnreadMessageCount()
+      }
+    }.asFlow()
   }
 
   fun getNumberOfUnseenStories(): Flow<Long> {

--- a/app/src/main/java/org/thoughtcrime/securesms/main/MainToolbar.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/main/MainToolbar.kt
@@ -109,6 +109,7 @@ interface MainToolbarCallback {
   fun onStarredMessagesClick()
   fun onNotificationProfileTooltipDismissed()
   fun onPendingGroupInvitesClick()
+  fun onParentalControlsClick()
 
   object Empty : MainToolbarCallback {
     override fun onNewGroupClick() = Unit
@@ -133,6 +134,7 @@ interface MainToolbarCallback {
     override fun onStarredMessagesClick() = Unit
     override fun onNotificationProfileTooltipDismissed() = Unit
     override fun onPendingGroupInvitesClick() = Unit
+    override fun onParentalControlsClick() = Unit
   }
 }
 
@@ -736,6 +738,17 @@ private fun ChatDropdownItems(state: MainToolbarState, callback: MainToolbarCall
       },
       onClick = {
         callback.onPendingGroupInvitesClick()
+        onOptionSelected()
+      }
+    )
+    DropdownMenus.Item(
+      text = {
+        Text(
+          text = stringResource(R.string.parental_controls_menu_item)
+        )
+      },
+      onClick = {
+        callback.onParentalControlsClick()
         onOptionSelected()
       }
     )

--- a/app/src/main/java/org/thoughtcrime/securesms/main/MainToolbar.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/main/MainToolbar.kt
@@ -665,17 +665,19 @@ private fun ChatDropdownItems(state: MainToolbarState, callback: MainToolbarCall
     )
   }
 
-  DropdownMenus.Item(
-    text = {
-      Text(
-        text = stringResource(R.string.text_secure_normal__menu_new_group)
-      )
-    },
-    onClick = {
-      callback.onNewGroupClick()
-      onOptionSelected()
-    }
-  )
+  if (!SignalStore.parentalControl.parentalModeEnabled) {
+    DropdownMenus.Item(
+      text = {
+        Text(
+          text = stringResource(R.string.text_secure_normal__menu_new_group)
+        )
+      },
+      onClick = {
+        callback.onNewGroupClick()
+        onOptionSelected()
+      }
+    )
+  }
 
   DropdownMenus.Item(
     text = {
@@ -741,18 +743,19 @@ private fun ChatDropdownItems(state: MainToolbarState, callback: MainToolbarCall
         onOptionSelected()
       }
     )
-    DropdownMenus.Item(
-      text = {
-        Text(
-          text = stringResource(R.string.parental_controls_menu_item)
-        )
-      },
-      onClick = {
-        callback.onParentalControlsClick()
-        onOptionSelected()
-      }
-    )
   }
+
+  DropdownMenus.Item(
+    text = {
+      Text(
+        text = stringResource(R.string.parental_controls_menu_item)
+      )
+    },
+    onClick = {
+      callback.onParentalControlsClick()
+      onOptionSelected()
+    }
+  )
 
   DropdownMenus.Item(
     text = {

--- a/app/src/main/java/org/thoughtcrime/securesms/main/MainToolbar.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/main/MainToolbar.kt
@@ -108,6 +108,7 @@ interface MainToolbarCallback {
   fun onSearchFilterClick()
   fun onStarredMessagesClick()
   fun onNotificationProfileTooltipDismissed()
+  fun onPendingGroupInvitesClick()
 
   object Empty : MainToolbarCallback {
     override fun onNewGroupClick() = Unit
@@ -131,6 +132,7 @@ interface MainToolbarCallback {
     override fun onSearchFilterClick() = Unit
     override fun onStarredMessagesClick() = Unit
     override fun onNotificationProfileTooltipDismissed() = Unit
+    override fun onPendingGroupInvitesClick() = Unit
   }
 }
 
@@ -720,6 +722,20 @@ private fun ChatDropdownItems(state: MainToolbarState, callback: MainToolbarCall
       },
       onClick = {
         callback.onStarredMessagesClick()
+        onOptionSelected()
+      }
+    )
+  }
+
+  if (SignalStore.parentalControl.parentalModeEnabled) {
+    DropdownMenus.Item(
+      text = {
+        Text(
+          text = stringResource(R.string.parental_pending_invites)
+        )
+      },
+      onClick = {
+        callback.onPendingGroupInvitesClick()
         onOptionSelected()
       }
     )

--- a/app/src/main/java/org/thoughtcrime/securesms/notifications/v2/DefaultMessageNotifier.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/notifications/v2/DefaultMessageNotifier.kt
@@ -168,6 +168,10 @@ class DefaultMessageNotifier(context: Application) : MessageNotifier {
     var state: NotificationState = NotificationStateProvider.constructNotificationState(stickyThreads, notificationProfile)
     Log.internal().i(TAG, "state: $state")
 
+    if (SignalStore.parentalControl.parentalModeEnabled) {
+      state = state.filterThreads(SignalStore.parentalControl.getAllowedThreadIds())
+    }
+
     if (state.muteFilteredMessages.isNotEmpty()) {
       Log.i(TAG, "Marking ${state.muteFilteredMessages.size} muted messages as notified to skip notification")
       state.muteFilteredMessages.forEach { item ->

--- a/app/src/main/java/org/thoughtcrime/securesms/notifications/v2/DefaultMessageNotifier.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/notifications/v2/DefaultMessageNotifier.kt
@@ -167,6 +167,10 @@ class DefaultMessageNotifier(context: Application) : MessageNotifier {
     var state: NotificationState = NotificationStateProvider.constructNotificationState(stickyThreads, notificationProfile)
     Log.internal().i(TAG, "state: $state")
 
+    if (SignalStore.parentalControl.parentalModeEnabled) {
+      state = state.filterThreads(SignalStore.parentalControl.getAllowedThreadIds())
+    }
+
     if (state.muteFilteredMessages.isNotEmpty()) {
       Log.i(TAG, "Marking ${state.muteFilteredMessages.size} muted messages as notified to skip notification")
       state.muteFilteredMessages.forEach { item ->

--- a/app/src/main/java/org/thoughtcrime/securesms/notifications/v2/NotificationState.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/notifications/v2/NotificationState.kt
@@ -88,6 +88,10 @@ data class NotificationState(val conversations: List<NotificationConversation>, 
 
   data class FilteredMessage(val id: Long, val isMms: Boolean)
 
+  fun filterThreads(allowedThreadIds: Set<Long>): NotificationState {
+    return copy(conversations = conversations.filter { it.thread.threadId in allowedThreadIds })
+  }
+
   companion object {
     val EMPTY = NotificationState(emptyList(), emptyList(), emptyList())
   }

--- a/app/src/main/java/org/thoughtcrime/securesms/parental/ParentalControlActivity.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/parental/ParentalControlActivity.kt
@@ -63,6 +63,11 @@ class ParentalControlActivity : AppCompatActivity() {
     }
   }
 
+  override fun onStop() {
+    super.onStop()
+    SignalStore.parentalControl.notifyChanged()
+  }
+
   private fun populateThreadList(threads: List<ParentalControlViewModel.ThreadItem>) {
     val container = binding.parentalThreadContainer
     container.removeAllViews()

--- a/app/src/main/java/org/thoughtcrime/securesms/parental/ParentalControlActivity.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/parental/ParentalControlActivity.kt
@@ -1,0 +1,138 @@
+package org.thoughtcrime.securesms.parental
+
+import android.content.Context
+import android.content.Intent
+import android.os.Bundle
+import android.text.InputType
+import android.widget.EditText
+import android.widget.LinearLayout
+import android.widget.TextView
+import android.widget.Toast
+import androidx.activity.viewModels
+import androidx.appcompat.app.AppCompatActivity
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
+import com.google.android.material.switchmaterial.SwitchMaterial
+import org.thoughtcrime.securesms.R
+import org.thoughtcrime.securesms.databinding.ActivityParentalControlBinding
+import org.thoughtcrime.securesms.keyvalue.SignalStore
+
+class ParentalControlActivity : AppCompatActivity() {
+
+  companion object {
+    const val EXTRA_SETUP_PIN = "extra_setup_pin"
+
+    fun createIntent(context: Context, setupPin: Boolean = false): Intent =
+      Intent(context, ParentalControlActivity::class.java)
+        .putExtra(EXTRA_SETUP_PIN, setupPin)
+  }
+
+  private lateinit var binding: ActivityParentalControlBinding
+  private val viewModel: ParentalControlViewModel by viewModels()
+
+  override fun onCreate(savedInstanceState: Bundle?) {
+    super.onCreate(savedInstanceState)
+    binding = ActivityParentalControlBinding.inflate(layoutInflater)
+    setContentView(binding.root)
+
+    setSupportActionBar(binding.parentalToolbar)
+    supportActionBar?.setDisplayHomeAsUpEnabled(true)
+    binding.parentalToolbar.setNavigationOnClickListener { finish() }
+
+    binding.parentalModeSwitch.setOnCheckedChangeListener(null)
+
+    viewModel.parentalEnabled.observe(this) { enabled ->
+      binding.parentalModeSwitch.setOnCheckedChangeListener(null)
+      binding.parentalModeSwitch.isChecked = enabled
+      binding.parentalModeSwitch.setOnCheckedChangeListener { _, isChecked ->
+        viewModel.setParentalEnabled(isChecked)
+      }
+    }
+
+    viewModel.threads.observe(this) { threads ->
+      populateThreadList(threads)
+    }
+
+    binding.parentalChangePinButton.setOnClickListener {
+      showChangePinDialog()
+    }
+
+    viewModel.load()
+
+    if (intent.getBooleanExtra(EXTRA_SETUP_PIN, false)) {
+      showSetupPinDialog()
+    }
+  }
+
+  private fun populateThreadList(threads: List<ParentalControlViewModel.ThreadItem>) {
+    val container = binding.parentalThreadContainer
+    container.removeAllViews()
+    for (item in threads) {
+      val row = layoutInflater.inflate(R.layout.item_parental_thread, container, false)
+      row.findViewById<TextView>(R.id.thread_name).text = item.displayName
+      val switch = row.findViewById<SwitchMaterial>(R.id.thread_allowed_switch)
+      switch.isChecked = item.allowed
+      switch.setOnCheckedChangeListener { _, isChecked ->
+        viewModel.toggleThread(item.threadId, isChecked)
+      }
+      container.addView(row)
+    }
+    if (threads.isEmpty()) {
+      val empty = TextView(this).apply {
+        text = getString(R.string.parental_no_pending_invites)
+        setPadding(0, 8, 0, 8)
+      }
+      container.addView(empty)
+    }
+  }
+
+  private fun showSetupPinDialog() {
+    showNewPinDialog(isSetup = true)
+  }
+
+  private fun showChangePinDialog() {
+    if (SignalStore.parentalControl.parentPinHash.isEmpty()) {
+      showNewPinDialog(isSetup = true)
+    } else {
+      ParentalPinDialog.show(this) {
+        showNewPinDialog(isSetup = false)
+      }
+    }
+  }
+
+  private fun showNewPinDialog(isSetup: Boolean) {
+    val layout = LinearLayout(this).apply {
+      orientation = LinearLayout.VERTICAL
+      val pad = resources.getDimensionPixelSize(R.dimen.dsl_settings_gutter)
+      setPadding(pad, pad / 2, pad, 0)
+    }
+
+    val pinInput = EditText(this).apply {
+      inputType = InputType.TYPE_CLASS_NUMBER or InputType.TYPE_NUMBER_VARIATION_PASSWORD
+      hint = getString(R.string.parental_new_pin_title)
+    }
+    val confirmInput = EditText(this).apply {
+      inputType = InputType.TYPE_CLASS_NUMBER or InputType.TYPE_NUMBER_VARIATION_PASSWORD
+      hint = getString(R.string.parental_confirm_pin_title)
+    }
+    layout.addView(pinInput)
+    layout.addView(confirmInput)
+
+    MaterialAlertDialogBuilder(this)
+      .setTitle(if (isSetup) R.string.parental_new_pin_title else R.string.parental_change_pin)
+      .setView(layout)
+      .setPositiveButton(android.R.string.ok) { _, _ ->
+        val pin = pinInput.text.toString()
+        val confirm = confirmInput.text.toString()
+        when {
+          pin.length < 4 ->
+            Toast.makeText(this, R.string.parental_pin_too_short, Toast.LENGTH_SHORT).show()
+          pin != confirm ->
+            Toast.makeText(this, R.string.parental_pin_mismatch, Toast.LENGTH_SHORT).show()
+          else ->
+            viewModel.changePin(this, pin)
+        }
+      }
+      .setNegativeButton(android.R.string.cancel, null)
+      .show()
+  }
+}

--- a/app/src/main/java/org/thoughtcrime/securesms/parental/ParentalControlViewModel.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/parental/ParentalControlViewModel.kt
@@ -1,0 +1,71 @@
+package org.thoughtcrime.securesms.parental
+
+import android.app.Application
+import android.content.Context
+import android.widget.Toast
+import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import org.thoughtcrime.securesms.R
+import org.thoughtcrime.securesms.database.SignalDatabase
+import org.thoughtcrime.securesms.keyvalue.ParentalControlValues
+import org.thoughtcrime.securesms.keyvalue.SignalStore
+
+class ParentalControlViewModel(application: Application) : AndroidViewModel(application) {
+
+  data class ThreadItem(val threadId: Long, val displayName: String, val allowed: Boolean)
+
+  private val _parentalEnabled = MutableLiveData(SignalStore.parentalControl.parentalModeEnabled)
+  val parentalEnabled: LiveData<Boolean> = _parentalEnabled
+
+  private val _threads = MutableLiveData<List<ThreadItem>>()
+  val threads: LiveData<List<ThreadItem>> = _threads
+
+  fun load() {
+    viewModelScope.launch(Dispatchers.IO) {
+      val allowedIds = SignalStore.parentalControl.getAllowedThreadIds()
+      val app = getApplication<Application>()
+      val items = mutableListOf<ThreadItem>()
+      val cursor = SignalDatabase.threads.getRecentConversationList(
+        limit = 500,
+        includeInactiveGroups = true,
+        hideV1Groups = false
+      )
+      SignalDatabase.threads.readerFor(cursor).use { reader ->
+        var record = reader.getNext()
+        while (record != null) {
+          items.add(
+            ThreadItem(
+              threadId = record.threadId,
+              displayName = record.recipient.getDisplayName(app),
+              allowed = record.threadId in allowedIds
+            )
+          )
+          record = reader.getNext()
+        }
+      }
+      _threads.postValue(items)
+    }
+  }
+
+  fun setParentalEnabled(enabled: Boolean) {
+    SignalStore.parentalControl.parentalModeEnabled = enabled
+    _parentalEnabled.value = enabled
+  }
+
+  fun toggleThread(threadId: Long, allowed: Boolean) {
+    val current = SignalStore.parentalControl.getAllowedThreadIds().toMutableSet()
+    if (allowed) current.add(threadId) else current.remove(threadId)
+    SignalStore.parentalControl.setAllowedThreadIds(current)
+    load()
+  }
+
+  fun changePin(context: Context, newPin: String) {
+    val salt = SignalStore.parentalControl.getPinSalt()
+    SignalStore.parentalControl.parentPinHash = ParentalControlValues.computePinHash(newPin, salt)
+    Toast.makeText(context, R.string.parental_pin_changed, Toast.LENGTH_SHORT).show()
+  }
+}

--- a/app/src/main/java/org/thoughtcrime/securesms/parental/ParentalPinDialog.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/parental/ParentalPinDialog.kt
@@ -1,0 +1,37 @@
+package org.thoughtcrime.securesms.parental
+
+import android.content.Context
+import android.text.InputType
+import android.widget.EditText
+import android.widget.Toast
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
+import org.thoughtcrime.securesms.R
+import org.thoughtcrime.securesms.keyvalue.SignalStore
+
+/**
+ * PIN entry dialog that gates parent-only actions.
+ * Shows a numeric password input; on correct PIN calls [onSuccess].
+ */
+object ParentalPinDialog {
+
+  fun show(context: Context, onSuccess: () -> Unit) {
+    val pinInput = EditText(context).apply {
+      inputType = InputType.TYPE_CLASS_NUMBER or InputType.TYPE_NUMBER_VARIATION_PASSWORD
+      hint = context.getString(R.string.parental_pin_dialog_hint)
+    }
+
+    MaterialAlertDialogBuilder(context)
+      .setTitle(R.string.parental_pin_dialog_title)
+      .setView(pinInput)
+      .setPositiveButton(android.R.string.ok) { _, _ ->
+        val entered = pinInput.text.toString()
+        if (SignalStore.parentalControl.verifyPin(entered)) {
+          onSuccess()
+        } else {
+          Toast.makeText(context, R.string.parental_incorrect_pin, Toast.LENGTH_SHORT).show()
+        }
+      }
+      .setNegativeButton(android.R.string.cancel, null)
+      .show()
+  }
+}

--- a/app/src/main/java/org/thoughtcrime/securesms/parental/PendingGroupInvitesFragment.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/parental/PendingGroupInvitesFragment.kt
@@ -1,0 +1,102 @@
+package org.thoughtcrime.securesms.parental
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.Button
+import android.widget.LinearLayout
+import android.widget.ScrollView
+import android.widget.TextView
+import android.widget.Toast
+import androidx.fragment.app.viewModels
+import com.google.android.material.bottomsheet.BottomSheetDialogFragment
+import org.thoughtcrime.securesms.R
+
+/**
+ * PIN-gated bottom sheet that lets a parent view and act on pending group invites.
+ * Must only be shown after successful PIN verification via [ParentalPinDialog].
+ */
+class PendingGroupInvitesFragment : BottomSheetDialogFragment() {
+
+  private val viewModel: PendingGroupInvitesViewModel by viewModels()
+
+  override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
+    val scrollView = ScrollView(requireContext())
+    val root = LinearLayout(requireContext()).apply {
+      orientation = LinearLayout.VERTICAL
+      setPadding(48, 48, 48, 48)
+    }
+    scrollView.addView(root)
+
+    val title = TextView(requireContext()).apply {
+      text = getString(R.string.parental_pending_invites)
+      textSize = 18f
+    }
+    root.addView(title)
+
+    viewModel.pendingInvites.observe(viewLifecycleOwner) { invites ->
+      root.removeViews(1, root.childCount - 1)
+
+      if (invites.isEmpty()) {
+        root.addView(TextView(requireContext()).apply {
+          text = getString(R.string.parental_no_pending_invites)
+          setPadding(0, 24, 0, 0)
+        })
+        return@observe
+      }
+
+      invites.forEach { item ->
+        val row = LinearLayout(requireContext()).apply {
+          orientation = LinearLayout.HORIZONTAL
+          setPadding(0, 16, 0, 16)
+        }
+
+        val name = TextView(requireContext()).apply {
+          text = item.groupName
+          layoutParams = LinearLayout.LayoutParams(0, LinearLayout.LayoutParams.WRAP_CONTENT, 1f)
+        }
+
+        val acceptBtn = Button(requireContext()).apply {
+          text = getString(R.string.parental_invite_accept)
+          setOnClickListener {
+            isEnabled = false
+            viewModel.acceptInvite(item) { reason ->
+              requireActivity().runOnUiThread {
+                Toast.makeText(requireContext(), "Failed (${reason.name})", Toast.LENGTH_SHORT).show()
+                isEnabled = true
+              }
+            }
+          }
+        }
+
+        val declineBtn = Button(requireContext()).apply {
+          text = getString(R.string.parental_invite_decline)
+          setOnClickListener {
+            isEnabled = false
+            viewModel.declineInvite(item) { reason ->
+              requireActivity().runOnUiThread {
+                Toast.makeText(requireContext(), "Failed (${reason.name})", Toast.LENGTH_SHORT).show()
+                isEnabled = true
+              }
+            }
+          }
+        }
+
+        row.addView(name)
+        row.addView(acceptBtn)
+        row.addView(declineBtn)
+        root.addView(row)
+      }
+    }
+
+    viewModel.load()
+    return scrollView
+  }
+
+  companion object {
+    fun show(fragmentManager: androidx.fragment.app.FragmentManager) {
+      PendingGroupInvitesFragment().show(fragmentManager, "pending_group_invites")
+    }
+  }
+}

--- a/app/src/main/java/org/thoughtcrime/securesms/parental/PendingGroupInvitesViewModel.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/parental/PendingGroupInvitesViewModel.kt
@@ -1,0 +1,74 @@
+package org.thoughtcrime.securesms.parental
+
+import android.app.Application
+import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import org.signal.core.util.concurrent.SignalExecutors
+import org.thoughtcrime.securesms.database.GroupTable
+import org.thoughtcrime.securesms.database.SignalDatabase
+import org.thoughtcrime.securesms.database.model.GroupRecord
+import org.thoughtcrime.securesms.groups.ui.GroupChangeErrorCallback
+import org.thoughtcrime.securesms.keyvalue.SignalStore
+import org.thoughtcrime.securesms.messagerequests.MessageRequestRepository
+import org.thoughtcrime.securesms.recipients.Recipient
+import org.thoughtcrime.securesms.recipients.RecipientId
+
+data class PendingInviteItem(
+  val recipientId: RecipientId,
+  val threadId: Long,
+  val groupName: String
+)
+
+class PendingGroupInvitesViewModel(app: Application) : AndroidViewModel(app) {
+
+  private val repository = MessageRequestRepository(app)
+
+  private val _pendingInvites = MutableLiveData<List<PendingInviteItem>>()
+  val pendingInvites: LiveData<List<PendingInviteItem>> = _pendingInvites
+
+  fun load() {
+    SignalExecutors.BOUNDED.execute {
+      val items = mutableListOf<PendingInviteItem>()
+      SignalDatabase.groups.getGroups().use { reader ->
+        var groupRecord: GroupRecord? = reader.getNext()
+        while (groupRecord != null) {
+          val record: GroupRecord = groupRecord
+          if (record.isV2Group && record.memberLevel(Recipient.self()) == GroupTable.MemberLevel.PENDING_MEMBER) {
+            val threadId = SignalDatabase.threads.getThreadIdFor(record.recipientId)
+            if (threadId != null) {
+              items += PendingInviteItem(
+                recipientId = record.recipientId,
+                threadId = threadId,
+                groupName = record.title?.ifBlank { null } ?: "Unknown group"
+              )
+            }
+          }
+          groupRecord = reader.getNext()
+        }
+      }
+      _pendingInvites.postValue(items)
+    }
+  }
+
+  fun acceptInvite(item: PendingInviteItem, onError: GroupChangeErrorCallback) {
+    repository.acceptMessageRequest(
+      item.recipientId,
+      item.threadId,
+      {
+        SignalStore.parentalControl.addAllowedThreadId(item.threadId)
+        load()
+      },
+      onError
+    )
+  }
+
+  fun declineInvite(item: PendingInviteItem, onError: GroupChangeErrorCallback) {
+    repository.deleteMessageRequest(
+      item.recipientId,
+      item.threadId,
+      { load() },
+      onError
+    )
+  }
+}

--- a/app/src/main/java/org/thoughtcrime/securesms/service/webrtc/IncomingCallActionProcessor.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/service/webrtc/IncomingCallActionProcessor.java
@@ -252,6 +252,12 @@ public class IncomingCallActionProcessor extends DeviceAwareActionProcessor {
                          .build();
     }
 
+    long threadId = SignalDatabase.threads().getThreadIdIfExistsFor(remotePeer.getId());
+    if (!SignalStore.parentalControl().isThreadCallAllowed(threadId)) {
+      Log.i(TAG, "Parental controls: rejecting incoming call from non-allowed thread.");
+      return handleDenyCall(currentState);
+    }
+
     webRtcInteractor.updatePhoneState(LockManager.PhoneState.INTERACTIVE);
     boolean started = webRtcInteractor.startWebRtcCallActivityIfPossible();
     if (!started) {

--- a/app/src/main/java/org/thoughtcrime/securesms/service/webrtc/IncomingCallActionProcessor.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/service/webrtc/IncomingCallActionProcessor.java
@@ -255,6 +255,12 @@ public class IncomingCallActionProcessor extends DeviceAwareActionProcessor {
                          .build();
     }
 
+    long threadId = SignalDatabase.threads().getThreadIdIfExistsFor(remotePeer.getId());
+    if (!SignalStore.parentalControl().isThreadCallAllowed(threadId)) {
+      Log.i(TAG, "Parental controls: rejecting incoming call from non-allowed thread.");
+      return handleDenyCall(currentState);
+    }
+
     webRtcInteractor.updatePhoneState(LockManager.PhoneState.INTERACTIVE);
     boolean started = webRtcInteractor.startWebRtcCallActivityIfPossible();
     if (!started) {

--- a/app/src/main/java/org/thoughtcrime/securesms/service/webrtc/IncomingGroupCallActionProcessor.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/service/webrtc/IncomingGroupCallActionProcessor.java
@@ -111,6 +111,17 @@ public final class IncomingGroupCallActionProcessor extends DeviceAwareActionPro
 
     Log.i(TAG, "Requesting new ring: " + ringId);
 
+    long groupThreadId = SignalDatabase.threads().getThreadIdIfExistsFor(remotePeerGroup.getId());
+    if (!SignalStore.parentalControl().isThreadCallAllowed(groupThreadId)) {
+      Log.i(TAG, "Parental controls: rejecting group ring from non-allowed thread.");
+      try {
+        webRtcInteractor.getCallManager().cancelGroupRing(groupId.getDecodedId(), ringId, CallManager.RingCancelReason.DeclinedByUser);
+      } catch (CallException e) {
+        Log.w(TAG, "Error cancelling parental-blocked group ring", e);
+      }
+      return currentState;
+    }
+
     Recipient ringerRecipient = Recipient.externalPush(sender);
     SignalDatabase.calls().insertOrUpdateGroupCallFromRingState(
         ringId,

--- a/app/src/main/java/org/thoughtcrime/securesms/util/CommunicationActions.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/util/CommunicationActions.java
@@ -40,6 +40,7 @@ import org.thoughtcrime.securesms.database.model.GroupRecord;
 import org.thoughtcrime.securesms.dependencies.AppDependencies;
 import org.thoughtcrime.securesms.groups.GroupId;
 import org.thoughtcrime.securesms.groups.ui.invitesandrequests.joining.GroupJoinBottomSheetDialogFragment;
+import org.thoughtcrime.securesms.keyvalue.SignalStore;
 import org.thoughtcrime.securesms.groups.ui.invitesandrequests.joining.GroupJoinUpdateRequiredBottomSheetDialogFragment;
 import org.thoughtcrime.securesms.groups.v2.GroupInviteLinkUrl;
 import org.signal.core.ui.permissions.Permissions;
@@ -289,6 +290,10 @@ public class CommunicationActions {
                                                                          : null;
     },
     recipient -> {
+      if (SignalStore.parentalControl().getParentalModeEnabled()) {
+        Toast.makeText(activity, R.string.parental_group_invite_blocked, Toast.LENGTH_SHORT).show();
+        return;
+      }
       if (recipient != null) {
         CommunicationActions.startConversation(activity, recipient, null);
         Toast.makeText(activity, R.string.GroupJoinBottomSheetDialogFragment_you_are_already_a_member, Toast.LENGTH_SHORT).show();

--- a/app/src/main/java/org/thoughtcrime/securesms/util/CommunicationActions.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/util/CommunicationActions.java
@@ -42,6 +42,7 @@ import org.thoughtcrime.securesms.database.model.GroupRecord;
 import org.thoughtcrime.securesms.dependencies.AppDependencies;
 import org.thoughtcrime.securesms.groups.GroupId;
 import org.thoughtcrime.securesms.groups.ui.invitesandrequests.joining.GroupJoinBottomSheetDialogFragment;
+import org.thoughtcrime.securesms.keyvalue.SignalStore;
 import org.thoughtcrime.securesms.groups.ui.invitesandrequests.joining.GroupJoinUpdateRequiredBottomSheetDialogFragment;
 import org.thoughtcrime.securesms.groups.v2.GroupInviteLinkUrl;
 import org.signal.core.ui.permissions.Permissions;
@@ -290,6 +291,10 @@ public class CommunicationActions {
                                                                          : null;
     },
     recipient -> {
+      if (SignalStore.parentalControl().getParentalModeEnabled()) {
+        Toast.makeText(activity, R.string.parental_group_invite_blocked, Toast.LENGTH_SHORT).show();
+        return;
+      }
       if (recipient != null) {
         CommunicationActions.startConversation(activity, recipient, null);
         Toast.makeText(activity, R.string.GroupJoinBottomSheetDialogFragment_you_are_already_a_member, Toast.LENGTH_SHORT).show();

--- a/app/src/main/res/layout/activity_parental_control.xml
+++ b/app/src/main/res/layout/activity_parental_control.xml
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical">
+
+    <com.google.android.material.appbar.MaterialToolbar
+        android:id="@+id/parental_toolbar"
+        android:layout_width="match_parent"
+        android:layout_height="?attr/actionBarSize"
+        app:navigationIcon="@drawable/ic_arrow_left_24"
+        app:title="@string/parental_controls_title" />
+
+    <androidx.core.widget.NestedScrollView
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1">
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            android:padding="16dp">
+
+            <!-- Section A: Master toggle -->
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:gravity="center_vertical"
+                android:orientation="horizontal"
+                android:paddingVertical="12dp">
+
+                <TextView
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:text="@string/parental_mode_enabled_label"
+                    android:textAppearance="@style/TextAppearance.Signal.Body1" />
+
+                <com.google.android.material.switchmaterial.SwitchMaterial
+                    android:id="@+id/parental_mode_switch"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content" />
+            </LinearLayout>
+
+            <View
+                android:layout_width="match_parent"
+                android:layout_height="1dp"
+                android:layout_marginVertical="8dp"
+                android:background="?attr/colorSurfaceVariant" />
+
+            <!-- Section B: Allowed chats -->
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="4dp"
+                android:text="@string/parental_allowed_chats_section"
+                android:textAppearance="@style/TextAppearance.Signal.Caption"
+                android:textColor="?attr/colorPrimary" />
+
+            <LinearLayout
+                android:id="@+id/parental_thread_container"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="vertical" />
+
+            <View
+                android:layout_width="match_parent"
+                android:layout_height="1dp"
+                android:layout_marginVertical="8dp"
+                android:background="?attr/colorSurfaceVariant" />
+
+            <!-- Section C: Change PIN -->
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/parental_change_pin_button"
+                style="@style/Widget.Signal.Button.Flat"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="@string/parental_change_pin" />
+
+        </LinearLayout>
+    </androidx.core.widget.NestedScrollView>
+
+</LinearLayout>

--- a/app/src/main/res/layout/item_parental_thread.xml
+++ b/app/src/main/res/layout/item_parental_thread.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:gravity="center_vertical"
+    android:minHeight="48dp"
+    android:orientation="horizontal"
+    android:paddingVertical="8dp">
+
+    <TextView
+        android:id="@+id/thread_name"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_weight="1"
+        android:ellipsize="end"
+        android:maxLines="1"
+        android:textAppearance="@style/TextAppearance.Signal.Body1" />
+
+    <com.google.android.material.switchmaterial.SwitchMaterial
+        android:id="@+id/thread_allowed_switch"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content" />
+
+</LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -9822,5 +9822,15 @@
     <!-- Body of the sheet shown when a local backup restore could not be completed, explaining how to try again -->
     <string mollyify="true" name="CouldNotCompleteBackupRestoreSheet__body_retry">To try again, uninstall and re-install Signal on this device, and choose \"Restore or transfer\".</string>
 
+    <!-- Parental controls -->
+    <string name="parental_group_invite_blocked">Ask a parent to add this group</string>
+    <string name="parental_incorrect_pin">Incorrect PIN</string>
+    <string name="parental_pending_invites">Pending group invites</string>
+    <string name="parental_no_pending_invites">No pending invites</string>
+    <string name="parental_pin_dialog_title">Parent PIN required</string>
+    <string name="parental_pin_dialog_hint">Enter PIN</string>
+    <string name="parental_invite_accept">Accept</string>
+    <string name="parental_invite_decline">Decline</string>
+
     <!-- EOF -->
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -9831,6 +9831,17 @@
     <string name="parental_pin_dialog_hint">Enter PIN</string>
     <string name="parental_invite_accept">Accept</string>
     <string name="parental_invite_decline">Decline</string>
+    <string name="parental_controls_menu_item">Parent Controls</string>
+    <string name="parental_controls_title">Parent Controls</string>
+    <string name="parental_mode_enabled_label">Parental mode enabled</string>
+    <string name="parental_allowed_chats_section">Allowed chats</string>
+    <string name="parental_change_pin">Change PIN</string>
+    <string name="parental_no_pin_set">No PIN set — tap to set one</string>
+    <string name="parental_new_pin_title">Set new PIN</string>
+    <string name="parental_confirm_pin_title">Confirm new PIN</string>
+    <string name="parental_pin_mismatch">PINs do not match</string>
+    <string name="parental_pin_changed">PIN updated</string>
+    <string name="parental_pin_too_short">PIN must be at least 4 digits</string>
 
     <!-- EOF -->
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -9973,5 +9973,15 @@
     <!-- Button declining to paste the recovery key -->
     <string name="RecoveryKeyWarningDialog__dont_share">Don\'t share</string>
 
+    <!-- Parental controls -->
+    <string name="parental_group_invite_blocked">Ask a parent to add this group</string>
+    <string name="parental_incorrect_pin">Incorrect PIN</string>
+    <string name="parental_pending_invites">Pending group invites</string>
+    <string name="parental_no_pending_invites">No pending invites</string>
+    <string name="parental_pin_dialog_title">Parent PIN required</string>
+    <string name="parental_pin_dialog_hint">Enter PIN</string>
+    <string name="parental_invite_accept">Accept</string>
+    <string name="parental_invite_decline">Decline</string>
+
     <!-- EOF -->
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -9982,6 +9982,17 @@
     <string name="parental_pin_dialog_hint">Enter PIN</string>
     <string name="parental_invite_accept">Accept</string>
     <string name="parental_invite_decline">Decline</string>
+    <string name="parental_controls_menu_item">Parent Controls</string>
+    <string name="parental_controls_title">Parent Controls</string>
+    <string name="parental_mode_enabled_label">Parental mode enabled</string>
+    <string name="parental_allowed_chats_section">Allowed chats</string>
+    <string name="parental_change_pin">Change PIN</string>
+    <string name="parental_no_pin_set">No PIN set — tap to set one</string>
+    <string name="parental_new_pin_title">Set new PIN</string>
+    <string name="parental_confirm_pin_title">Confirm new PIN</string>
+    <string name="parental_pin_mismatch">PINs do not match</string>
+    <string name="parental_pin_changed">PIN updated</string>
+    <string name="parental_pin_too_short">PIN must be at least 4 digits</string>
 
     <!-- EOF -->
 </resources>

--- a/app/src/test/java/org/thoughtcrime/securesms/conversationlist/ConversationListParentalFilterTest.kt
+++ b/app/src/test/java/org/thoughtcrime/securesms/conversationlist/ConversationListParentalFilterTest.kt
@@ -1,0 +1,93 @@
+package org.thoughtcrime.securesms.conversationlist
+
+import assertk.assertThat
+import assertk.assertions.containsExactly
+import assertk.assertions.isEmpty
+import assertk.assertions.isEqualTo
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.Test
+import org.thoughtcrime.securesms.conversationlist.model.Conversation
+import org.thoughtcrime.securesms.database.model.ThreadRecord
+
+class ConversationListParentalFilterTest {
+
+  private fun threadConversation(id: Long): Conversation {
+    val thread = mockk<ThreadRecord>(relaxed = true)
+    every { thread.threadId } returns id
+    return Conversation(thread)
+  }
+
+  private fun headerConversation(type: Conversation.Type): Conversation {
+    val thread = mockk<ThreadRecord>(relaxed = true)
+    every { thread.threadId } returns -(type.ordinal.toLong() + 1)
+    every { thread.body } returns type.name
+    return Conversation(thread)
+  }
+
+  @Test
+  fun `parental mode OFF - all threads returned unchanged`() {
+    val t1 = threadConversation(1L)
+    val t2 = threadConversation(2L)
+    val result = ConversationListViewModel.applyParentalFilter(listOf(t1, t2), enabled = false, allowedIds = setOf(1L))
+    assertThat(result).containsExactly(t1, t2)
+  }
+
+  @Test
+  fun `parental mode ON - allowed thread passes through`() {
+    val t1 = threadConversation(1L)
+    val result = ConversationListViewModel.applyParentalFilter(listOf(t1), enabled = true, allowedIds = setOf(1L))
+    assertThat(result).containsExactly(t1)
+  }
+
+  @Test
+  fun `parental mode ON - disallowed thread is removed`() {
+    val t1 = threadConversation(1L)
+    val result = ConversationListViewModel.applyParentalFilter(listOf(t1), enabled = true, allowedIds = setOf(99L))
+    assertThat(result).isEmpty()
+  }
+
+  @Test
+  fun `parental mode ON - only allowed thread remains when list has both`() {
+    val allowed = threadConversation(1L)
+    val blocked = threadConversation(2L)
+    val result = ConversationListViewModel.applyParentalFilter(listOf(allowed, blocked), enabled = true, allowedIds = setOf(1L))
+    assertThat(result).containsExactly(allowed)
+  }
+
+  @Test
+  fun `parental mode ON - empty allowed set removes all threads`() {
+    val t1 = threadConversation(1L)
+    val t2 = threadConversation(2L)
+    val result = ConversationListViewModel.applyParentalFilter(listOf(t1, t2), enabled = true, allowedIds = emptySet())
+    assertThat(result).isEmpty()
+  }
+
+  @Test
+  fun `parental mode ON - non-THREAD header items are never filtered`() {
+    val header = headerConversation(Conversation.Type.PINNED_HEADER)
+    val allowed = threadConversation(1L)
+    val blocked = threadConversation(2L)
+    val footer = headerConversation(Conversation.Type.ARCHIVED_FOOTER)
+    val result = ConversationListViewModel.applyParentalFilter(
+      listOf(header, allowed, blocked, footer),
+      enabled = true,
+      allowedIds = setOf(1L)
+    )
+    assertThat(result).containsExactly(header, allowed, footer)
+  }
+
+  @Test
+  fun `parental mode ON - all threads allowed returns full list`() {
+    val t1 = threadConversation(1L)
+    val t2 = threadConversation(2L)
+    val result = ConversationListViewModel.applyParentalFilter(listOf(t1, t2), enabled = true, allowedIds = setOf(1L, 2L))
+    assertThat(result).containsExactly(t1, t2)
+  }
+
+  @Test
+  fun `empty list - always returns empty`() {
+    val result = ConversationListViewModel.applyParentalFilter(emptyList(), enabled = true, allowedIds = setOf(1L))
+    assertThat(result).isEmpty()
+  }
+}

--- a/app/src/test/java/org/thoughtcrime/securesms/conversationlist/ConversationListParentalFilterTest.kt
+++ b/app/src/test/java/org/thoughtcrime/securesms/conversationlist/ConversationListParentalFilterTest.kt
@@ -8,18 +8,18 @@ import io.mockk.every
 import io.mockk.mockk
 import org.junit.Test
 import org.thoughtcrime.securesms.conversationlist.model.Conversation
-import org.thoughtcrime.securesms.database.model.ThreadRecord
+import org.thoughtcrime.securesms.database.model.ThreadWithRecipient
 
 class ConversationListParentalFilterTest {
 
   private fun threadConversation(id: Long): Conversation {
-    val thread = mockk<ThreadRecord>(relaxed = true)
+    val thread = mockk<ThreadWithRecipient>(relaxed = true)
     every { thread.threadId } returns id
     return Conversation(thread)
   }
 
   private fun headerConversation(type: Conversation.Type): Conversation {
-    val thread = mockk<ThreadRecord>(relaxed = true)
+    val thread = mockk<ThreadWithRecipient>(relaxed = true)
     every { thread.threadId } returns -(type.ordinal.toLong() + 1)
     every { thread.body } returns type.name
     return Conversation(thread)

--- a/app/src/test/java/org/thoughtcrime/securesms/keyvalue/ParentalCallGuardTest.kt
+++ b/app/src/test/java/org/thoughtcrime/securesms/keyvalue/ParentalCallGuardTest.kt
@@ -1,0 +1,84 @@
+package org.thoughtcrime.securesms.keyvalue
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import org.junit.Test
+
+/**
+ * Verifies the parental-control guards introduced in Phase 3:
+ *
+ *  - New conversation / new call activities finish immediately when parental mode is on.
+ *    The guard condition is `parentalModeEnabled == true`; tested here via the data model.
+ *
+ *  - Incoming calls from non-allowed threads are rejected.
+ *    The guard uses [ParentalControlValues.isThreadCallAllowed]; covered here and in
+ *    ParentalControlValuesTest.
+ */
+class ParentalCallGuardTest {
+
+  private fun createValues(): ParentalControlValues {
+    val storage = object : KeyValuePersistentStorage {
+      private val dataSet = KeyValueDataSet()
+      override fun writeDataSet(newDataSet: KeyValueDataSet, removes: Collection<String>) {
+        dataSet.removeAll(removes)
+        dataSet.putAll(newDataSet)
+      }
+      override fun getDataSet(): KeyValueDataSet = dataSet
+    }
+    return ParentalControlValues(KeyValueStore(storage))
+  }
+
+  // --- Activity guard condition (NewConversationActivity / NewCallActivity) ---
+
+  @Test
+  fun `activity guard - parental mode ON means new conversation should be blocked`() {
+    val values = createValues()
+    // Default is true; guard is `if (parentalModeEnabled) finish()`
+    assertThat(values.parentalModeEnabled).isEqualTo(true)
+  }
+
+  @Test
+  fun `activity guard - parental mode OFF means new conversation is allowed`() {
+    val values = createValues()
+    values.parentalModeEnabled = false
+    assertThat(values.parentalModeEnabled).isEqualTo(false)
+  }
+
+  // --- Incoming call guard (1:1 and group): isThreadCallAllowed ---
+
+  @Test
+  fun `call guard - parental mode ON, allowed thread - call permitted`() {
+    val values = createValues()
+    values.setAllowedThreadIds(setOf(10L))
+    assertThat(values.isThreadCallAllowed(10L)).isEqualTo(true)
+  }
+
+  @Test
+  fun `call guard - parental mode ON, non-allowed thread - call blocked`() {
+    val values = createValues()
+    values.setAllowedThreadIds(setOf(10L))
+    assertThat(values.isThreadCallAllowed(99L)).isEqualTo(false)
+  }
+
+  @Test
+  fun `call guard - parental mode ON, no thread exists (id -1) - call blocked`() {
+    val values = createValues()
+    values.setAllowedThreadIds(setOf(10L))
+    assertThat(values.isThreadCallAllowed(-1L)).isEqualTo(false)
+  }
+
+  @Test
+  fun `call guard - parental mode OFF - any thread allowed regardless of allowlist`() {
+    val values = createValues()
+    values.parentalModeEnabled = false
+    values.setAllowedThreadIds(setOf(10L))
+    assertThat(values.isThreadCallAllowed(99L)).isEqualTo(true)
+  }
+
+  @Test
+  fun `call guard - parental mode ON, empty allowlist - all calls blocked`() {
+    val values = createValues()
+    values.setAllowedThreadIds(emptySet())
+    assertThat(values.isThreadCallAllowed(10L)).isEqualTo(false)
+  }
+}

--- a/app/src/test/java/org/thoughtcrime/securesms/keyvalue/ParentalControlValuesTest.kt
+++ b/app/src/test/java/org/thoughtcrime/securesms/keyvalue/ParentalControlValuesTest.kt
@@ -1,0 +1,117 @@
+package org.thoughtcrime.securesms.keyvalue
+
+import assertk.assertThat
+import assertk.assertions.containsExactly
+import assertk.assertions.isEmpty
+import assertk.assertions.isEqualTo
+import assertk.assertions.isNotEmpty
+import assertk.assertions.isNotEqualTo
+import org.junit.Test
+
+class ParentalControlValuesTest {
+
+  private fun createValues(): ParentalControlValues {
+    val dataset = KeyValueDataSet()
+    val store = KeyValueStore(dataset)
+    return ParentalControlValues(store)
+  }
+
+  @Test
+  fun `fresh defaults - parental mode enabled`() {
+    val values = createValues()
+    assertThat(values.parentalModeEnabled).isEqualTo(true)
+  }
+
+  @Test
+  fun `fresh defaults - pin hash empty`() {
+    val values = createValues()
+    assertThat(values.parentPinHash).isEqualTo("")
+  }
+
+  @Test
+  fun `fresh defaults - allowed thread ids empty`() {
+    val values = createValues()
+    assertThat(values.getAllowedThreadIds()).isEmpty()
+  }
+
+  @Test
+  fun `toggle parental mode enabled to disabled`() {
+    val values = createValues()
+    values.parentalModeEnabled = false
+    assertThat(values.parentalModeEnabled).isEqualTo(false)
+  }
+
+  @Test
+  fun `toggle parental mode disabled to enabled`() {
+    val values = createValues()
+    values.parentalModeEnabled = false
+    values.parentalModeEnabled = true
+    assertThat(values.parentalModeEnabled).isEqualTo(true)
+  }
+
+  @Test
+  fun `pin hash round trip`() {
+    val values = createValues()
+    val hash = "abc123def456"
+    values.parentPinHash = hash
+    assertThat(values.parentPinHash).isEqualTo(hash)
+  }
+
+  @Test
+  fun `compute pin hash determinism`() {
+    val pin = "1234"
+    val salt = byteArrayOf(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)
+    val hash1 = ParentalControlValues.computePinHash(pin, salt)
+    val hash2 = ParentalControlValues.computePinHash(pin, salt)
+    assertThat(hash1).isEqualTo(hash2)
+  }
+
+  @Test
+  fun `compute pin hash uniqueness with different salt`() {
+    val pin = "1234"
+    val salt1 = byteArrayOf(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)
+    val salt2 = byteArrayOf(1, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)
+    val hash1 = ParentalControlValues.computePinHash(pin, salt1)
+    val hash2 = ParentalControlValues.computePinHash(pin, salt2)
+    assertThat(hash1).isNotEqualTo(hash2)
+  }
+
+  @Test
+  fun `salt auto generated on first call`() {
+    val values = createValues()
+    val salt = values.getPinSalt()
+    assertThat(salt).isNotEmpty()
+    assertThat(salt.size).isEqualTo(16)
+  }
+
+  @Test
+  fun `salt returns same value on second call`() {
+    val values = createValues()
+    val salt1 = values.getPinSalt()
+    val salt2 = values.getPinSalt()
+    assertThat(salt1).isEqualTo(salt2)
+  }
+
+  @Test
+  fun `allowed thread ids round trip`() {
+    val values = createValues()
+    val ids = setOf(1L, 2L, 3L)
+    values.setAllowedThreadIds(ids)
+    assertThat(values.getAllowedThreadIds()).containsExactly(1L, 2L, 3L)
+  }
+
+  @Test
+  fun `allowed thread ids empty set`() {
+    val values = createValues()
+    values.setAllowedThreadIds(emptySet())
+    assertThat(values.getAllowedThreadIds()).isEmpty()
+  }
+
+  @Test
+  fun `allowed thread ids clear after set`() {
+    val values = createValues()
+    values.setAllowedThreadIds(setOf(1L, 2L))
+    values.setAllowedThreadIds(emptySet())
+    assertThat(values.getAllowedThreadIds()).isEmpty()
+  }
+}

--- a/app/src/test/java/org/thoughtcrime/securesms/keyvalue/ParentalControlValuesTest.kt
+++ b/app/src/test/java/org/thoughtcrime/securesms/keyvalue/ParentalControlValuesTest.kt
@@ -1,7 +1,6 @@
 package org.thoughtcrime.securesms.keyvalue
 
 import assertk.assertThat
-import assertk.assertions.containsExactly
 import assertk.assertions.isEmpty
 import assertk.assertions.isEqualTo
 import assertk.assertions.isNotEmpty
@@ -11,9 +10,15 @@ import org.junit.Test
 class ParentalControlValuesTest {
 
   private fun createValues(): ParentalControlValues {
-    val dataset = KeyValueDataSet()
-    val store = KeyValueStore(dataset)
-    return ParentalControlValues(store)
+    val storage = object : KeyValuePersistentStorage {
+      private val dataSet = KeyValueDataSet()
+      override fun writeDataSet(newDataSet: KeyValueDataSet, removes: kotlin.collections.Collection<String>) {
+        dataSet.removeAll(removes)
+        dataSet.putAll(newDataSet)
+      }
+      override fun getDataSet(): KeyValueDataSet = dataSet
+    }
+    return ParentalControlValues(KeyValueStore(storage))
   }
 
   @Test
@@ -97,7 +102,7 @@ class ParentalControlValuesTest {
     val values = createValues()
     val ids = setOf(1L, 2L, 3L)
     values.setAllowedThreadIds(ids)
-    assertThat(values.getAllowedThreadIds()).containsExactly(1L, 2L, 3L)
+    assertThat(values.getAllowedThreadIds()).isEqualTo(setOf(1L, 2L, 3L))
   }
 
   @Test

--- a/app/src/test/java/org/thoughtcrime/securesms/keyvalue/ParentalControlValuesTest.kt
+++ b/app/src/test/java/org/thoughtcrime/securesms/keyvalue/ParentalControlValuesTest.kt
@@ -139,4 +139,77 @@ class ParentalControlValuesTest {
     values.setAllowedThreadIds(setOf(1L, 2L))
     assertThat(emissions.size).isEqualTo(1)
   }
+
+  @Test
+  fun `isThreadCallAllowed - parental mode OFF - any thread allowed`() {
+    val values = createValues()
+    values.parentalModeEnabled = false
+    assertThat(values.isThreadCallAllowed(99L)).isEqualTo(true)
+  }
+
+  @Test
+  fun `isThreadCallAllowed - parental mode ON - allowed thread permitted`() {
+    val values = createValues()
+    values.setAllowedThreadIds(setOf(1L, 2L))
+    assertThat(values.isThreadCallAllowed(1L)).isEqualTo(true)
+  }
+
+  @Test
+  fun `isThreadCallAllowed - parental mode ON - non-allowed thread blocked`() {
+    val values = createValues()
+    values.setAllowedThreadIds(setOf(1L, 2L))
+    assertThat(values.isThreadCallAllowed(99L)).isEqualTo(false)
+  }
+
+  @Test
+  fun `isThreadCallAllowed - parental mode ON - unknown thread (id -1) blocked`() {
+    val values = createValues()
+    values.setAllowedThreadIds(setOf(1L, 2L))
+    assertThat(values.isThreadCallAllowed(-1L)).isEqualTo(false)
+  }
+
+  @Test
+  fun `isThreadCallAllowed - parental mode ON - empty allowed set blocks all`() {
+    val values = createValues()
+    values.setAllowedThreadIds(emptySet())
+    assertThat(values.isThreadCallAllowed(1L)).isEqualTo(false)
+  }
+
+  @Test
+  fun `verifyPin - correct pin returns true`() {
+    val values = createValues()
+    val pin = "7890"
+    values.parentPinHash = ParentalControlValues.computePinHash(pin, values.getPinSalt())
+    assertThat(values.verifyPin(pin)).isEqualTo(true)
+  }
+
+  @Test
+  fun `verifyPin - wrong pin returns false`() {
+    val values = createValues()
+    values.parentPinHash = ParentalControlValues.computePinHash("1234", values.getPinSalt())
+    assertThat(values.verifyPin("9999")).isEqualTo(false)
+  }
+
+  @Test
+  fun `verifyPin - empty hash returns false`() {
+    val values = createValues()
+    assertThat(values.parentPinHash).isEqualTo("")
+    assertThat(values.verifyPin("1234")).isEqualTo(false)
+  }
+
+  @Test
+  fun `addAllowedThreadId - appends without replacing existing`() {
+    val values = createValues()
+    values.setAllowedThreadIds(setOf(1L, 2L))
+    values.addAllowedThreadId(3L)
+    assertThat(values.getAllowedThreadIds()).isEqualTo(setOf(1L, 2L, 3L))
+  }
+
+  @Test
+  fun `addAllowedThreadId - idempotent when id already present`() {
+    val values = createValues()
+    values.setAllowedThreadIds(setOf(1L, 2L))
+    values.addAllowedThreadId(2L)
+    assertThat(values.getAllowedThreadIds()).isEqualTo(setOf(1L, 2L))
+  }
 }

--- a/app/src/test/java/org/thoughtcrime/securesms/keyvalue/ParentalControlValuesTest.kt
+++ b/app/src/test/java/org/thoughtcrime/securesms/keyvalue/ParentalControlValuesTest.kt
@@ -6,6 +6,7 @@ import assertk.assertions.isEqualTo
 import assertk.assertions.isNotEmpty
 import assertk.assertions.isNotEqualTo
 import org.junit.Test
+import java.util.concurrent.CopyOnWriteArrayList
 
 class ParentalControlValuesTest {
 
@@ -118,5 +119,24 @@ class ParentalControlValuesTest {
     values.setAllowedThreadIds(setOf(1L, 2L))
     values.setAllowedThreadIds(emptySet())
     assertThat(values.getAllowedThreadIds()).isEmpty()
+  }
+
+  @Test
+  fun `settingsChanges emits when parental mode toggled`() {
+    val values = createValues()
+    val emissions = CopyOnWriteArrayList<Unit>()
+    values.settingsChanges.subscribe { emissions.add(Unit) }
+    values.parentalModeEnabled = false
+    values.parentalModeEnabled = true
+    assertThat(emissions.size).isEqualTo(2)
+  }
+
+  @Test
+  fun `settingsChanges emits when allowed thread ids updated`() {
+    val values = createValues()
+    val emissions = CopyOnWriteArrayList<Unit>()
+    values.settingsChanges.subscribe { emissions.add(Unit) }
+    values.setAllowedThreadIds(setOf(1L, 2L))
+    assertThat(emissions.size).isEqualTo(1)
   }
 }

--- a/app/src/test/java/org/thoughtcrime/securesms/keyvalue/ParentalControlViewModelTest.kt
+++ b/app/src/test/java/org/thoughtcrime/securesms/keyvalue/ParentalControlViewModelTest.kt
@@ -1,0 +1,78 @@
+package org.thoughtcrime.securesms.keyvalue
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isFalse
+import assertk.assertions.isTrue
+import org.junit.Test
+
+/**
+ * Unit tests for the business logic exercised by ParentalControlViewModel.
+ * Tests operate directly on ParentalControlValues (the source of truth) since
+ * the ViewModel is a thin delegation layer on top of it.
+ */
+class ParentalControlViewModelTest {
+
+  private fun createValues(): ParentalControlValues {
+    val storage = object : KeyValuePersistentStorage {
+      private val dataSet = KeyValueDataSet()
+      override fun writeDataSet(newDataSet: KeyValueDataSet, removes: Collection<String>) {
+        dataSet.removeAll(removes)
+        dataSet.putAll(newDataSet)
+      }
+      override fun getDataSet(): KeyValueDataSet = dataSet
+    }
+    return ParentalControlValues(KeyValueStore(storage))
+  }
+
+  @Test
+  fun `freshInstall noPinSet parentPinHashIsEmpty`() {
+    val values = createValues()
+    assertThat(values.parentPinHash).isEqualTo("")
+  }
+
+  @Test
+  fun `setParentalEnabled true stores true`() {
+    val values = createValues()
+    values.parentalModeEnabled = false
+    values.parentalModeEnabled = true
+    assertThat(values.parentalModeEnabled).isTrue()
+  }
+
+  @Test
+  fun `setParentalEnabled false stores false`() {
+    val values = createValues()
+    values.parentalModeEnabled = false
+    assertThat(values.parentalModeEnabled).isFalse()
+  }
+
+  @Test
+  fun `toggleThread add updatesAllowedSet`() {
+    val values = createValues()
+    val threadId = 42L
+    val current = values.getAllowedThreadIds().toMutableSet()
+    current.add(threadId)
+    values.setAllowedThreadIds(current)
+    assertThat(values.getAllowedThreadIds()).isEqualTo(setOf(threadId))
+  }
+
+  @Test
+  fun `toggleThread remove updatesAllowedSet`() {
+    val values = createValues()
+    val threadId = 42L
+    values.setAllowedThreadIds(setOf(threadId, 99L))
+    val current = values.getAllowedThreadIds().toMutableSet()
+    current.remove(threadId)
+    values.setAllowedThreadIds(current)
+    assertThat(values.getAllowedThreadIds()).isEqualTo(setOf(99L))
+  }
+
+  @Test
+  fun `changePin updatesStoredHash and verifyPin succeeds`() {
+    val values = createValues()
+    val newPin = "1234"
+    val salt = values.getPinSalt()
+    values.parentPinHash = ParentalControlValues.computePinHash(newPin, salt)
+    assertThat(values.verifyPin(newPin)).isTrue()
+  }
+}

--- a/app/src/test/java/org/thoughtcrime/securesms/keyvalue/ParentalInviteGuardTest.kt
+++ b/app/src/test/java/org/thoughtcrime/securesms/keyvalue/ParentalInviteGuardTest.kt
@@ -1,0 +1,82 @@
+package org.thoughtcrime.securesms.keyvalue
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isFalse
+import assertk.assertions.isTrue
+import org.junit.Test
+
+/**
+ * Tests for Phase 4 invite-gating helpers: verifyPin and addAllowedThreadId.
+ * In the keyvalue package to access package-private test helpers (per lessons from Phase 3).
+ */
+class ParentalInviteGuardTest {
+
+  private fun createValues(): ParentalControlValues {
+    val storage = object : KeyValuePersistentStorage {
+      private val dataSet = KeyValueDataSet()
+      override fun writeDataSet(newDataSet: KeyValueDataSet, removes: Collection<String>) {
+        dataSet.removeAll(removes)
+        dataSet.putAll(newDataSet)
+      }
+      override fun getDataSet(): KeyValueDataSet = dataSet
+    }
+    return ParentalControlValues(KeyValueStore(storage))
+  }
+
+  @Test
+  fun `verifyPin correct pin`() {
+    val values = createValues()
+    val pin = "4321"
+    values.parentPinHash = ParentalControlValues.computePinHash(pin, values.getPinSalt())
+    assertThat(values.verifyPin(pin)).isTrue()
+  }
+
+  @Test
+  fun `verifyPin wrong pin`() {
+    val values = createValues()
+    values.parentPinHash = ParentalControlValues.computePinHash("1111", values.getPinSalt())
+    assertThat(values.verifyPin("9999")).isFalse()
+  }
+
+  @Test
+  fun `verifyPin empty hash is always false`() {
+    val values = createValues()
+    assertThat(values.verifyPin("")).isFalse()
+    assertThat(values.verifyPin("1234")).isFalse()
+  }
+
+  @Test
+  fun `addAllowedThreadId appends correctly`() {
+    val values = createValues()
+    values.setAllowedThreadIds(setOf(10L, 20L))
+    values.addAllowedThreadId(30L)
+    assertThat(values.getAllowedThreadIds()).isEqualTo(setOf(10L, 20L, 30L))
+  }
+
+  @Test
+  fun `allowedThreadIds includes newly added invite thread`() {
+    val values = createValues()
+    val inviteThreadId = 99L
+    values.addAllowedThreadId(inviteThreadId)
+    assertThat(values.getAllowedThreadIds().contains(inviteThreadId)).isTrue()
+  }
+
+  @Test
+  fun `addAllowedThreadId is idempotent`() {
+    val values = createValues()
+    values.setAllowedThreadIds(setOf(5L))
+    values.addAllowedThreadId(5L)
+    assertThat(values.getAllowedThreadIds()).isEqualTo(setOf(5L))
+  }
+
+  @Test
+  fun `verifyPin uses same salt for consistency`() {
+    val values = createValues()
+    val pin = "5678"
+    val salt = values.getPinSalt()
+    values.parentPinHash = ParentalControlValues.computePinHash(pin, salt)
+    assertThat(values.verifyPin(pin)).isTrue()
+    assertThat(values.verifyPin(pin)).isTrue()
+  }
+}

--- a/app/src/test/java/org/thoughtcrime/securesms/keyvalue/ParentalNavigationFilterTest.kt
+++ b/app/src/test/java/org/thoughtcrime/securesms/keyvalue/ParentalNavigationFilterTest.kt
@@ -1,0 +1,39 @@
+package org.thoughtcrime.securesms.keyvalue
+
+import assertk.assertThat
+import assertk.assertions.contains
+import assertk.assertions.doesNotContain
+import org.junit.Test
+import org.thoughtcrime.securesms.main.MainNavigationListLocation
+import org.thoughtcrime.securesms.main.buildNavEntries
+
+class ParentalNavigationFilterTest {
+
+  @Test
+  fun `parental ON and stories feature ON - STORIES absent, CHATS and CALLS present`() {
+    val entries = buildNavEntries(isStoriesEnabled = true, parentalModeEnabled = true)
+    assertThat(entries).doesNotContain(MainNavigationListLocation.STORIES)
+    assertThat(entries).contains(MainNavigationListLocation.CHATS)
+    assertThat(entries).contains(MainNavigationListLocation.CALLS)
+  }
+
+  @Test
+  fun `parental OFF and stories feature ON - STORIES present, CHATS and CALLS present`() {
+    val entries = buildNavEntries(isStoriesEnabled = true, parentalModeEnabled = false)
+    assertThat(entries).contains(MainNavigationListLocation.STORIES)
+    assertThat(entries).contains(MainNavigationListLocation.CHATS)
+    assertThat(entries).contains(MainNavigationListLocation.CALLS)
+  }
+
+  @Test
+  fun `parental ON and stories feature OFF - STORIES absent`() {
+    val entries = buildNavEntries(isStoriesEnabled = false, parentalModeEnabled = true)
+    assertThat(entries).doesNotContain(MainNavigationListLocation.STORIES)
+  }
+
+  @Test
+  fun `parental OFF and stories feature OFF - STORIES absent due to feature flag`() {
+    val entries = buildNavEntries(isStoriesEnabled = false, parentalModeEnabled = false)
+    assertThat(entries).doesNotContain(MainNavigationListLocation.STORIES)
+  }
+}

--- a/app/src/test/java/org/thoughtcrime/securesms/notifications/v2/NotificationStateParentalFilterTest.kt
+++ b/app/src/test/java/org/thoughtcrime/securesms/notifications/v2/NotificationStateParentalFilterTest.kt
@@ -1,0 +1,64 @@
+package org.thoughtcrime.securesms.notifications.v2
+
+import assertk.assertThat
+import assertk.assertions.isEmpty
+import assertk.assertions.isEqualTo
+import io.mockk.mockk
+import org.junit.Test
+
+class NotificationStateParentalFilterTest {
+
+  private fun conversationWithThread(threadId: Long): NotificationConversation {
+    return NotificationConversation(
+      recipient = mockk(relaxed = true),
+      thread = ConversationId(threadId, null),
+      notificationItems = listOf(mockk(relaxed = true))
+    )
+  }
+
+  @Test
+  fun `filterThreads - allowed thread is retained`() {
+    val state = NotificationState(listOf(conversationWithThread(1L)), emptyList(), emptyList())
+    val filtered = state.filterThreads(setOf(1L))
+    assertThat(filtered.conversations.map { it.thread.threadId }).isEqualTo(listOf(1L))
+  }
+
+  @Test
+  fun `filterThreads - disallowed thread is removed`() {
+    val state = NotificationState(listOf(conversationWithThread(2L)), emptyList(), emptyList())
+    val filtered = state.filterThreads(setOf(1L))
+    assertThat(filtered.conversations).isEmpty()
+  }
+
+  @Test
+  fun `filterThreads - mixed threads keeps only allowed`() {
+    val state = NotificationState(
+      listOf(conversationWithThread(1L), conversationWithThread(2L), conversationWithThread(3L)),
+      emptyList(),
+      emptyList()
+    )
+    val filtered = state.filterThreads(setOf(1L, 3L))
+    assertThat(filtered.conversations.map { it.thread.threadId }).isEqualTo(listOf(1L, 3L))
+  }
+
+  @Test
+  fun `filterThreads - empty allowed set removes all conversations`() {
+    val state = NotificationState(
+      listOf(conversationWithThread(1L), conversationWithThread(2L)),
+      emptyList(),
+      emptyList()
+    )
+    val filtered = state.filterThreads(emptySet())
+    assertThat(filtered.conversations).isEmpty()
+  }
+
+  @Test
+  fun `filterThreads - muteFilteredMessages and profileFilteredMessages are preserved`() {
+    val muteMsg = NotificationState.FilteredMessage(1L, false)
+    val profileMsg = NotificationState.FilteredMessage(2L, true)
+    val state = NotificationState(listOf(conversationWithThread(99L)), listOf(muteMsg), listOf(profileMsg))
+    val filtered = state.filterThreads(emptySet())
+    assertThat(filtered.muteFilteredMessages).isEqualTo(listOf(muteMsg))
+    assertThat(filtered.profileFilteredMessages).isEqualTo(listOf(profileMsg))
+  }
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,5 @@
 org.gradle.jvmargs=-Xmx12g -XX:+UseParallelGC
+org.gradle.java.home=C:/Program Files/Eclipse Adoptium/jdk-21.0.10.7-hotspot
 android.useAndroidX=true
 org.gradle.configuration-cache=true
 org.gradle.configuration-cache.problems=fail
@@ -10,6 +11,7 @@ org.gradle.parallel=true
 # this flag adds an extra layer of protection.
 # See: https://docs.gradle.org/current/userguide/toolchains.html#sub:disable_auto_provision
 org.gradle.java.installations.auto-download=false
+org.gradle.java.installations.paths=C:/Program Files/Eclipse Adoptium/jdk-21.0.10.7-hotspot
 
 # Test fixtures support for Android modules
 android.experimental.enableTestFixturesKotlinSupport=true


### PR DESCRIPTION
## Summary

This PR adds an **opt-in `kids` Gradle build flavor** to Molly that enables parental controls
for families who want to use Signal-compatible messaging with young children.

All changes are behind the `kids` flavor flag. The existing `prod` and `staging` flavors are
completely unaffected — this is purely additive.

---

## Motivation

Families with young children often want a secure, private messaging channel with grandparents,
relatives, and family friends. Signal is an excellent technical foundation for this, but it has
no concept of a "restricted" child account. The child can message anyone, see all contacts, and
change account settings.

This fork adds a PIN-gated parental layer so parents can:
- Allow only specific group chats to be visible to the child
- Block the child from starting new conversations or making calls
- Prevent access to account settings, Stories, and linked device management
- Manage the allow-list from a parent settings panel on the child's device

Registration uses free Google Voice numbers so children never expose personal phone numbers.
Communication happens via Signal usernames, requiring no app changes.

---

## What's in this PR

| Phase | Feature |
|---|---|
| 0 | `kids` Gradle build flavor + `parentalModeEnabled` flag |
| 1 | `ParentalControlValues.kt` — PIN storage (SHA-256 + random salt) and allowed-thread list |
| 2 | Conversation list filtering — show only allowed threads |
| 3 & 4 | Block new outbound conversations/calls; gate group invites behind PIN |
| 5 | Suppress notifications from non-allowed threads |
| 6 | Hide Stories tab and lock account/linked-device settings |
| 7 | `ParentalControlActivity` — PIN-gated parent settings panel on the child's device |

**62 unit tests** cover the parental-control layer. All pass on the current build.

---

## Architecture — why this is safe to merge

**New files only for parental logic.** All parental UI and data live in:
- `app/src/main/java/.../keyvalue/ParentalControlValues.kt`
- `app/src/main/java/.../parental/` (Activity, ViewModel, dialogs)

**Minimal touch of existing files.** Guard clauses are added at a handful of call sites:
```kotlin
if (SignalStore.parental().parentalModeEnabled) { /* restrict */ }
```
No Signal protocol, crypto, database schema, or network code is modified.

**Zero-conflict upstream tracking.** This branch is based on Molly's current `main` and has
been kept in sync through multiple upstream releases with zero merge conflicts.

**Opt-in at build time.** A standard `./gradlew assembleProdRelease` produces the normal Molly
APK. The parental controls only activate in a `kidsRelease` build.

---

## Public fork

The full fork with history and documentation is at:
**https://github.com/avacar/mollykids-android**

---

## Notes for reviewers

- If this scope is too large to consider for mainline Molly, I'm happy to discuss a narrower
  contribution (e.g. just the `kids` flavor scaffolding in Phase 0, with the rest maintained
  downstream).
- The `ParentalControlActivity` is intentionally a standalone `AppCompatActivity` rather than
  a destination in `AppSettingsActivity`'s NavGraph, to avoid upstream merge conflicts in the
  settings navigation graph.
- The PIN is stored as `SHA-256(salt + PIN)` with a random 16-byte salt. No plaintext PIN is
  ever persisted.
