### PR TITLE
Fix linking a device: advertise usernameChangeSyncMessage capability (Fixes #770)

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/AppCapabilities.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/AppCapabilities.kt
@@ -13,7 +13,8 @@ object AppCapabilities {
       storage = storageCapable,
       versionedExpirationTimer = true,
       attachmentBackfill = true,
-      spqr = true
+      spqr = true,
+      usernameChangeSyncMessage = true
     )
   }
 }

--- a/app/src/main/java/org/thoughtcrime/securesms/registration/ui/link/RegisterLinkDeviceQrViewModel.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/registration/ui/link/RegisterLinkDeviceQrViewModel.kt
@@ -146,6 +146,7 @@ class RegisterLinkDeviceQrViewModel : ViewModel() {
   fun clearErrors() {
     store.update {
       it.copy(
+        isRegistering = false,
         showProvisioningError = false,
         registrationErrorResult = null
       )
@@ -156,7 +157,10 @@ class RegisterLinkDeviceQrViewModel : ViewModel() {
 
   fun setRegisterAsLinkedDeviceError(result: RegisterLinkDeviceResult) {
     store.update {
-      it.copy(registrationErrorResult = result)
+      it.copy(
+        isRegistering = false,
+        registrationErrorResult = result
+      )
     }
   }
 

--- a/lib/libsignal-service/src/main/java/org/whispersystems/signalservice/api/account/AccountAttributes.kt
+++ b/lib/libsignal-service/src/main/java/org/whispersystems/signalservice/api/account/AccountAttributes.kt
@@ -57,6 +57,7 @@ class AccountAttributes @JsonCreator constructor(
     @JsonProperty val storage: Boolean,
     @JsonProperty val versionedExpirationTimer: Boolean,
     @JsonProperty val attachmentBackfill: Boolean,
-    @JsonProperty val spqr: Boolean
+    @JsonProperty val spqr: Boolean,
+    @JsonProperty val usernameChangeSyncMessage: Boolean = false
   )
 }


### PR DESCRIPTION
## Problem
Linking Molly as a secondary device to a current Signal primary fails. The QR is scanned but the device never registers and the screen spins indefinitely. Fixes #770.

## Root cause
`PUT /v1/devices/link` is rejected with HTTP 409. The server's capability-downgrade check requires a new linked device to advertise every `preventDowngrade` capability the account already has. Current Signal clients advertise `usernameChangeSyncMessage` (added upstream, `preventDowngrade=true`), so the account has it, but Molly doesn't send it, so the link is treated as a downgrade and refused.

## Fix
Advertise `usernameChangeSyncMessage` in the device capabilities, matching current Signal. Added to `AccountAttributes.Capabilities` (defaulted, so other call sites are untouched) and set to true in `AppCapabilities`.

A second commit resets `isRegistering` on link failure so an error dialog is shown instead of an indefinite spinner. Previously any post-scan failure was masked by the progress dialog, which is why this surfaced as an endless loop.

## Testing
Built `prodWebsiteDebug` and linked against a primary running Signal 8.17. 

* **Before:** HTTP 409, endless spinner

* **After:** Link succeeds (server assigns a device id) and the device appears in the primary's linked-devices list. No dependency/native changes.
