### PR TITLE
Add JVM args to improve R8 determinism for reproducibility

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,11 @@
-org.gradle.jvmargs=-Xmx12g -XX:+UseParallelGC
+# R8 in AGP 9.x is non-deterministic, producing intermittent dex differences between
+# otherwise-identical builds. Two flags work together to stabilize it:
+#   - -Dcom.android.tools.r8.threadCount=1 removes thread-scheduling-dependent ordering.
+#   - -XX:hashCode=3 (deterministic incrementing Object.identityHashCode) removes
+#     IdentityHashMap iteration-order non-determinism inside R8 (e.g. in
+#     KotlinClassMetadataReader, which decides whether to keep the Signature attribute
+#     on Kotlin generic lambda subclasses).
+org.gradle.jvmargs=-Xmx12g -Xms256m -XX:MaxMetaspaceSize=1g -Dcom.android.tools.r8.threadCount=1 -XX:+UnlockExperimentalVMOptions -XX:hashCode=3
 org.gradle.parallel=true
 
 android.useAndroidX=true


### PR DESCRIPTION
Actually, Molly is no longer reproducible (see this workflow: [29643368147](https://github.com/BarbossHack/reproducible/actions/runs/29643368147/job/88077412428))

> <img width="1026" height="552" alt="image" src="https://github.com/user-attachments/assets/ac4c0f61-4e83-43e0-97b0-cc5990708cba" />


.

I first reported the issue upstream in https://github.com/signalapp/Signal-Android/issues/14809 and it has already been fixed. However, it seems that not all of the fixes have been merged into Molly.

The relevant code was taken from an upstream commit made two months ago: https://github.com/signalapp/Signal-Android/commit/09822d3ae9879565f78fd8a62e4393599df929e9