### PR TITLE
docs: improve copying of signing certificate hash

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,10 +35,23 @@ You can also get **Molly-FOSS** from [Accrescent](https://accrescent.app/):
 </a>
 
 To [verify](https://developer.android.com/studio/command-line/apksigner#usage-verify) the APK, use the following signing certificate fingerprints:
+
+<details open>
+    <summary>SHA-256</summary>
+    
 ```
-SHA-256: 6aa80fdf4a8cc13737cfb434fc0cde486f09cf8fcda21a67bea5ee1ca2700886
-SHA-1: 49ce310cdd0c09c8c34eb31a8005c6bf13f5a4f1
+6aa80fdf4a8cc13737cfb434fc0cde486f09cf8fcda21a67bea5ee1ca2700886
 ```
+
+</details>
+<details>
+    <summary>SHA-1</summary>
+
+```
+49ce310cdd0c09c8c34eb31a8005c6bf13f5a4f1
+```
+    
+</details>
 
 ## Features
 


### PR DESCRIPTION
Set's the SHA-256 and SHA-1 signing certificate hash in their own code block. This allows for easier copying / pasting, and thus improves the UX when verifying.

Both are in their own details block. SHA-256 is open to encourage it's use. And SHA-1 is closed as it's has collision attack vulnerabilities.

Please check the hash was not corrupted.

I would encourage that the SHA-1 hash be dropped due to aforementioned vulnerabilities.